### PR TITLE
Add calendar view and notes tweaks

### DIFF
--- a/backend/app/static/follow.html
+++ b/backend/app/static/follow.html
@@ -82,7 +82,7 @@ function renderOrders(){
         <input type="datetime-local" value="${o.scheduledTime||''}" onchange="updateScheduledTime('${d}','${o.orderName}',this.value)">
         <input type="number" value="${o.cashAmount||''}" placeholder="Cash" onchange="updateCash('${d}','${o.orderName}',this.value)">
         <textarea placeholder="Notes to driver" onchange="updateNotes('${d}','${o.orderName}',this.value)">${o.notes||''}</textarea>
-        <textarea class="follow-log" placeholder="Follow log" onchange="updateFollow('${d}','${o.orderName}',this.value)">${o.followLog||''}</textarea>
+        <textarea class="follow-log" placeholder="Internal comments" onchange="updateFollow('${d}','${o.orderName}',this.value)">${o.followLog||''}</textarea>
         <div id="comm-${key}" class="comm-log"></div>
       </div>`;
     });

--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -661,6 +661,7 @@
         📷 Scanner
       </button>
       <button class="nav-tab" onclick="showTab('orders')">📋 Orders</button>
+      <button class="nav-tab" onclick="showTab('calendar')">📅 Calendar</button>
       <button class="nav-tab" onclick="showTab('followups')">
         🚨 Follow-Ups
       </button>
@@ -716,6 +717,15 @@
       <div id="ordersContainer" class="orders-container">
         <div class="loading">Click here to load orders</div>
         <button class="scan-btn" onclick="loadOrders()">📋 Load Orders</button>
+      </div>
+    </div>
+
+    <div id="calendar-tab" class="tab-content">
+      <div style="margin-bottom:1rem;text-align:center;">
+        <input id="calDate" type="date" onchange="showCalendar()"/>
+      </div>
+      <div id="calendarContainer" class="orders-container">
+        <div class="loading">Select a date to view scheduled orders</div>
       </div>
     </div>
 
@@ -975,6 +985,10 @@
           if (t === "orders" && !orders.length) loadOrders();
           if (t === "followups") loadFollowUps();
           if (t === "archive") loadArchive();
+          if (t === "calendar") {
+            if (!orders.length) loadOrders().then(showCalendar);
+            else showCalendar();
+          }
           if (t === "payouts" && !payouts.length) loadPayouts();
           if (t === "stats") applyDefaultRange();
         }
@@ -1051,7 +1065,7 @@
         function loadOrders() {
           document.getElementById("ordersContainer").innerHTML =
             '<div class="loading">Loading orders...</div>';
-          apiGet(`/orders?driver=${driver_id}`)
+          return apiGet(`/orders?driver=${driver_id}`)
             .then(displayOrders)
             .catch(
               (e) =>
@@ -1300,6 +1314,19 @@
           c.innerHTML = h;
           orders.forEach((o) => displayCommunicationLog(o.orderName));
           startCountdown();
+        }
+
+        function showCalendar() {
+          const date = document.getElementById("calDate").value;
+          if (!date) {
+            document.getElementById("calendarContainer").innerHTML =
+              '<div class="no-orders">Select a date</div>';
+            return;
+          }
+          const list = orders.filter(
+            (o) => o.scheduledTime && o.scheduledTime.startsWith(date)
+          );
+          displayOrdersCommon(list, document.getElementById("calendarContainer"), false);
         }
 
         /* ─────────────────────────────────────────────────────────────
@@ -1644,6 +1671,7 @@
           loadStatsRange,
           applyDefaultRange,
           selectQuickRange,
+          showCalendar,
           recordCall,
           recordWhatsapp,
         });


### PR DESCRIPTION
## Summary
- add Calendar tab to driver dashboard
- show scheduled orders by date
- expose showCalendar helper and load orders when Calendar tab opens
- return promise from `loadOrders`
- rename Follow agent comment field

## Testing
- `python -m py_compile backend/app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_687151c8c2d083219330c726dea96b18