### PR TITLE
Fix SQLAlchemy NOT IN filter for orders queries

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -531,7 +531,7 @@ async def list_active_orders(driver: str = Query(...)):
         result = await session.execute(
             select(Order).where(
                 Order.driver_id == driver,
-                Order.delivery_status.not_in(COMPLETED_STATUSES),
+                Order.delivery_status.notin_(COMPLETED_STATUSES),
             )
         )
         rows = result.scalars().all()
@@ -638,7 +638,7 @@ async def list_followup_orders(driver: str = Query(...)):
         result = await session.execute(
             select(Order).where(
                 Order.driver_id == driver,
-                Order.delivery_status.not_in(COMPLETED_STATUSES),
+                Order.delivery_status.notin_(COMPLETED_STATUSES),
             )
         )
         rows = result.scalars().all()


### PR DESCRIPTION
## Summary
- correct the `not_in` method to `notin_` for SQLAlchemy queries

## Testing
- `python -m py_compile backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_687165085c6883218bd5b4ee2c03b698