### PR TITLE
Fix duplicate CORSMiddleware import

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,7 +27,6 @@ from fastapi.responses import HTMLResponse, FileResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
 from pydantic import BaseModel
-from starlette.middleware.cors import CORSMiddleware
 
 from sqlalchemy import select, or_
 from sqlalchemy.ext.asyncio import AsyncSession


### PR DESCRIPTION
## Summary
- tidy up imports in `main.py` by removing duplicate `CORSMiddleware` import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68719094e0a48321972d8f905ad59aa7