### PR TITLE
Fix timezone error in followups view

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -739,7 +739,8 @@ async def list_followup_orders(driver: str = Query(...)):
         rows = result.scalars().all()
 
         followups = []
-        now = dt.datetime.now(timezone.utc)
+        # Use a naive timestamp to match values loaded from SQLite/PG
+        now = dt.datetime.utcnow()
         for o in rows:
             last_update = o.timestamp
             if o.status_log:


### PR DESCRIPTION
## Summary
- fix datetime comparison in `/orders/followups` by using `utcnow()`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6871a9ce1b2c8321b30c0ff092459246