### PR TITLE
Enhance follow-up notes and archive handling

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -69,8 +69,9 @@ DELIVERY_STATUSES = [
     "Refusé",
     "Rescheduled",
     "Returned",
+    "Deleted",
 ]
-COMPLETED_STATUSES = ["Livré", "Annulé", "Refusé", "Returned"]
+COMPLETED_STATUSES = ["Livré", "Annulé", "Refusé", "Returned", "Deleted"]
 NORMAL_DELIVERY_FEE = 20
 EXCHANGE_DELIVERY_FEE = 10
 

--- a/backend/app/static/follow.html
+++ b/backend/app/static/follow.html
@@ -224,14 +224,14 @@ function renderSection(dataObj,container,includeInputs,showDone,showUndone){
         <div>${o.customerPhone?`📞 ${o.customerPhone} <a href="tel:${o.customerPhone}" onclick="return recordCall('${key}')">📞</a> ${waUrl?`<a href="${waUrl}" target="_blank" onclick="return recordWhatsapp('${key}')">💬</a>`:''}`:''}</div>
         <div>${o.address||''}</div>
         <div>Timestamp: ${o.timestamp}</div>
-        ${o.driverNotes?`<div class="driver-log">${formatDriverNotes(o.driverNotes)}</div>`:''}`;
+        ${o.driverNotes?`<div class="driver-log">🚚 ${formatDriverNotes(o.driverNotes)}</div>`:''}`;
       if(includeInputs){
         html+=`<select class="status-select" onchange="updateOrderStatus('${d}','${o.orderName}',this.value)">`+
         deliveryStatuses.map(s=>`<option value="${s}"${s===o.deliveryStatus?' selected':''} style="background:${statusColors[s]||'#fff'}">${s}</option>`).join('')+
         `</select>`+
         `<input type="datetime-local" value="${o.scheduledTime||''}" onchange="updateScheduledTime('${d}','${o.orderName}',this.value)">`+
         `<input type="number" value="${o.cashAmount||''}" placeholder="Cash" onchange="updateCash('${d}','${o.orderName}',this.value)">`+
-        `<textarea placeholder="Notes to driver" onchange="updateNotes('${d}','${o.orderName}',this.value)">${o.notes||''}</textarea>`;
+        `<div class="agent-note">👤 <textarea placeholder="Notes to driver" onchange="updateNotes('${d}','${o.orderName}',this.value)">${o.notes||''}</textarea></div>`;
       }
       html+=`<textarea class="follow-log" placeholder="Follow log" onchange="updateFollow('${d}','${o.orderName}',this.value)">${o.followLog||''}</textarea>`+
         `<div id="comm-${key}" class="comm-log"></div>`+
@@ -242,6 +242,9 @@ function renderSection(dataObj,container,includeInputs,showDone,showUndone){
       if(showUndone){
         html+=`<button class="undone-btn" onclick="markUndone('${d}','${o.orderName}')">Undone</button>`;
       }
+      if(includeInputs){
+        html+=`<button class="delete-btn" onclick="archiveOrder('${d}','${o.orderName}')">🗑️ Archive</button>`;
+      }
       html+=`</div>`;
     });
     html+='</div>';
@@ -251,7 +254,58 @@ function renderSection(dataObj,container,includeInputs,showDone,showUndone){
 }
 
 function renderOrders(){renderSection(ordersData,document.getElementById('ordersContainer'),true,true,false);}
-function renderArchive(){renderSection(archiveData,document.getElementById('archive'),false,false,false);}
+function renderArchive(){
+  const container=document.getElementById('archive');
+  const filter=(document.getElementById('searchInput').value||'').toLowerCase();
+  const status=document.getElementById('statusFilter').value||'';
+  container.innerHTML='';
+  for(const [d,orders] of Object.entries(archiveData)){
+    if(driverFilterVal && d!==driverFilterVal) continue;
+    const filtered=orders.filter(o=>{
+      const phone=(o.customerPhone||'').toLowerCase();
+      const name=(o.customerName||'').toLowerCase();
+      const order=o.orderName.toLowerCase();
+      const matchesText=!filter||order.includes(filter)||phone.includes(filter)||name.includes(filter);
+      const matchesStatus=!status||o.deliveryStatus===status;
+      return matchesText&&matchesStatus;
+    });
+    if(!filtered.length) continue;
+    const colors=['#ff5722','#4caf50','#03a9f4','#ff9800','#e91e63','#009688'];
+    const idx=driversCache.indexOf(d);
+    const color=colors[idx%colors.length];
+    let html=`<div class="driver-section"><h2 style="color:${color}">${d.toUpperCase()}</h2>`;
+    const weeks={};
+    filtered.forEach(o=>{
+      const dt=new Date(o.timestamp.replace(' ','T'));
+      const monday=new Date(dt);monday.setDate(dt.getDate()-((dt.getDay()+6)%7));
+      const key=monday.toISOString().slice(0,10);
+      (weeks[key]=weeks[key]||[]).push(o);
+    });
+    Object.keys(weeks).sort((a,b)=>new Date(b)-new Date(a)).forEach(w=>{
+      html+=`<details class="archive-week"><summary>${w}</summary>`;
+      weeks[w].forEach(o=>{
+        const key=`${d}_${o.orderName}`;
+        const border=statusColors[o.deliveryStatus]||'#004aad';
+        const waUrl=o.customerPhone?`https://wa.me/${o.customerPhone}`:'';
+        html+=`<div id="card-${key}" class="order-card" style="border-left-color:${border}">`+
+          `<div class="order-header"><span style="font-size:1.2rem;font-weight:bold">${o.orderName}</span><span style="font-size:0.9rem">${o.deliveryStatus}</span></div>`+
+          `<div>${o.customerName||''}</div>`+
+          `<div>${o.customerPhone?`📞 ${o.customerPhone}`:''}</div>`+
+          `<div>${o.address||''}</div>`+
+          `<div>Timestamp: ${o.timestamp}</div>`+
+          `${o.driverNotes?`<div class="driver-log">🚚 ${formatDriverNotes(o.driverNotes)}</div>`:''}`+
+          `${o.notes?`<div class="agent-note">👤 ${o.notes}</div>`:''}`+
+          `<textarea class="follow-log" readonly>${o.followLog||''}</textarea>`+
+          `${o.statusLog?`<div class="status-log">${o.statusLog.replace(/\|/g,'\n')}</div>`:''}`+
+          `</div>`;
+      });
+      html+='</details>';
+    });
+    html+='</div>';
+    container.innerHTML+=html;
+    filtered.forEach(o=>displayCommunicationLog(`${d}_${o.orderName}`));
+  }
+}
 function renderDone(){
   const data={};
   for(const [k,v] of Object.entries(doneData)){
@@ -368,6 +422,10 @@ function loadDone(){try{doneData=JSON.parse(localStorage.getItem('doneOrders')||
 function purgeExpiredDone(){const now=Date.now();let changed=false;for(const [k,v] of Object.entries(doneData)){if(now-v.time>4*3600*1000){delete doneData[k];changed=true;}}if(changed)saveDone();}
 function markDone(driver,order){const arr=ordersData[driver]||[];const idx=arr.findIndex(o=>o.orderName===order);if(idx>=0){const o=arr[idx];doneData[`${driver}_${order}`]={time:Date.now(),order:o};arr.splice(idx,1);saveDone();renderOrders();renderDone();updateFollow(driver,order,(o.followLog||'')+`\nDone @ ${new Date().toLocaleString()}`);}}
 function markUndone(driver,order){const key=`${driver}_${order}`;const info=doneData[key];if(info){delete doneData[key];saveDone();renderDone();loadOrders(driversCache);updateFollow(driver,order,(info.order.followLog||'')+`\nUndone @ ${new Date().toLocaleString()}`);}}
+function archiveOrder(driver,order){
+  if(!confirm('Archive this order?')) return;
+  updateOrderStatus(driver,order,'Deleted');
+}
 function populateDriverFilter(){const container=document.getElementById('driverFilter');if(!container)return;container.innerHTML='';const colors=['#ff5722','#4caf50','#03a9f4','#ff9800','#e91e63','#009688'];let i=0;const allBtn=document.createElement('button');allBtn.textContent='All';allBtn.style.background='#607d8b';allBtn.onclick=()=>{driverFilterVal='';applyDriverFilter();};container.appendChild(allBtn);driversCache.forEach(d=>{const b=document.createElement('button');b.textContent=d;b.style.background=colors[i%colors.length];i++;b.onclick=()=>{driverFilterVal=d;applyDriverFilter();};container.appendChild(b);});}
 
 function formatDriverNotes(notes){

--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -466,7 +466,7 @@
           </div>
         </div>
         <div class="agent-notes">
-          <div class="agent-label">🧭 Agent Instructions</div>
+          <div class="agent-label">👤 Agent Notes</div>
           <div class="agent-text">${o.notes||''}</div>
         </div>
         <details class="actions-block">
@@ -496,7 +496,7 @@
         <div class="driver-notes-section">
           <textarea id="note-${o.orderName}" class="driver-note-input" placeholder="Add note…"></textarea>
           <button class="add-note-btn" onclick="addOrderNote('${o.orderName}')">Add Note</button>
-          <div class="notes-list">${(o.driverNotes||'').split('\n').filter(Boolean).map(n=>`<div class="note-item">${n}</div>`).join('')}</div>
+          <div class="notes-list">${(o.driverNotes||'').split('\n').filter(Boolean).map(n=>`<div class="note-item">🚚 ${n}</div>`).join('')}</div>
           ${o.statusLog?`<div class="status-log">${o.statusLog.replace(/\|/g,'\n')}</div>`:''}
         </div>
       </div>`;


### PR DESCRIPTION
## Summary
- add `Deleted` status for archiving orders
- show agent and driver notes with clear icons
- allow follow dashboard to archive orders
- display archived orders grouped by week

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6871bc5bd4dc83218c9782f9eab2e658