### PR TITLE
Fix follow dashboard orders filter

### DIFF
--- a/backend/app/static/follow.html
+++ b/backend/app/static/follow.html
@@ -147,8 +147,7 @@ async function loadOrders(drivers){
       .catch(e=>{alert(`Error loading orders for ${d}: `+e);return {driver:d,data:[]};})
   ));
   results.forEach(r=>{
-    const statuses=['Pas de réponse 3','Annulé','Refusé'];
-    const filtered=r.data.filter(o=>statuses.includes(o.deliveryStatus)&&!doneData[`${r.driver}_${o.orderName}`]);
+    const filtered=r.data.filter(o=>!doneData[`${r.driver}_${o.orderName}`]);
     if(recentUpdateKey){
       filtered.sort((a,b)=>{
         const ka=`${r.driver}_${a.orderName}`;


### PR DESCRIPTION
## Summary
- update follow dashboard to load all active orders in Today Suivi tab

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6871beac2f908321b3d8fa4c9bc974b4