### PR TITLE
Add migrate_sheet util script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Delivery App Scan V2
+
+## Sheet Migration
+
+This repository includes a helper script for importing orders from a Google Sheet into the database.
+
+### Required environment variables
+
+- `GOOGLE_APPLICATION_CREDENTIALS` – path to a Google service account json file.
+- `SHEET_ID` – spreadsheet identifier or name.
+- `DATABASE_URL` – SQLAlchemy database url.
+- `DRIVER_ID` – optional driver id for created orders (defaults to `abderrehman`).
+
+### Usage
+
+Run the migration script with Python:
+
+```bash
+python backend/scripts/migrate_sheet.py
+```
+
+The script reads the sheet specified by `SHEET_ID` and inserts every row after the header as an `Order` in the database.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,5 @@ SQLAlchemy[asyncio]==2.0.30
 redis[hiredis]==5.0.4
 fakeredis==2.21.0
 pytest==8.2.0
+gspread==6.1.0
+google-auth==2.29.0

--- a/backend/scripts/migrate_sheet.py
+++ b/backend/scripts/migrate_sheet.py
@@ -1,0 +1,67 @@
+import os
+import asyncio
+from datetime import datetime
+
+import gspread
+from backend.app.db import Order, AsyncSessionLocal
+
+
+async def insert_orders(rows: list[dict], driver_id: str) -> None:
+    async with AsyncSessionLocal() as session:
+        for data in rows:
+            kwargs = {}
+            for column in Order.__table__.columns.keys():
+                if column == "id":
+                    continue
+                if column == "driver_id":
+                    kwargs[column] = data.get(column, driver_id)
+                elif column == "timestamp":
+                    value = data.get(column)
+                    if value:
+                        try:
+                            value = datetime.fromisoformat(value)
+                        except Exception:
+                            try:
+                                value = datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+                            except Exception:
+                                value = datetime.utcnow()
+                    else:
+                        value = datetime.utcnow()
+                    kwargs[column] = value
+                elif column in {"cash_amount", "driver_fee"}:
+                    value = data.get(column)
+                    kwargs[column] = float(value) if value not in (None, "") else None
+                else:
+                    kwargs[column] = data.get(column)
+            order = Order(**kwargs)
+            session.add(order)
+        await session.commit()
+
+
+def load_sheet() -> list[dict]:
+    creds_path = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+    identifier = os.environ["SHEET_ID"]
+    gc = gspread.service_account(filename=creds_path)
+    try:
+        sheet = gc.open_by_key(identifier)
+    except Exception:
+        sheet = gc.open(identifier)
+    ws = sheet.sheet1
+    values = ws.get_all_values()
+    if not values:
+        return []
+    header = [h.strip() for h in values[0]]
+    rows = []
+    for row in values[1:]:
+        rows.append(dict(zip(header, row)))
+    return rows
+
+
+async def main() -> None:
+    driver_id = os.getenv("DRIVER_ID", "abderrehman")
+    rows = load_sheet()
+    await insert_orders(rows, driver_id)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add README with instructions for migrating from Google Sheets
- support `gspread` and `google-auth`
- provide `backend/scripts/migrate_sheet.py` helper to import orders

## Testing
- `pip install -r backend/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6872551f4e64832183270dc0a3f46b1f