### PR TITLE
Add admin payouts table

### DIFF
--- a/backend/app/static/admin_dashboard.html
+++ b/backend/app/static/admin_dashboard.html
@@ -7,14 +7,14 @@
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   <style>
-    body{font-family:sans-serif;background:linear-gradient(to bottom,#f5f7fa,#e2e8f0);min-height:100vh;margin:0;}
+    body{font-family:'Inter', 'Poppins', 'Roboto', sans-serif;background:linear-gradient(to bottom,#f5f7fa,#e2e8f0);min-height:100vh;margin:0;}
     .tab{padding:0.75rem 1rem;cursor:pointer;font-weight:600;}
     .tab.active{background:#2563eb;color:white;border-radius:0.5rem 0.5rem 0 0;}
     .tab-content{display:none;padding:1rem;}
     .tab-content.active{display:block;}
   </style>
 </head>
-<body class="text-gray-800">
+<body class="text-gray-800 dark:bg-gray-900 dark:text-gray-200">
   <div class="bg-white shadow p-4 flex justify-between items-center">
     <div class="text-2xl font-bold text-blue-700">Admin Dashboard</div>
     <div class="flex items-center space-x-2">
@@ -29,6 +29,7 @@
     <div class="tab active" data-tab="overview" onclick="activateTab('overview')">Statistics Overview</div>
     <div class="tab" data-tab="orders" onclick="activateTab('orders');loadOrdersTab()">Orders</div>
     <div class="tab" data-tab="parcels" onclick="activateTab('parcels');loadParcelsTab()">Parcels DB</div>
+    <div class="tab" data-tab="payouts" onclick="activateTab('payouts');loadPayoutsTab()">Payouts DB</div>
     <div class="tab" data-tab="placeholder" onclick="activateTab('placeholder')">Other</div>
   </div>
 
@@ -121,6 +122,32 @@
           </tr>
         </thead>
         <tbody id="parcelsBody"></tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- Payouts database tab -->
+  <div id="payouts" class="tab-content">
+    <h2 class="text-lg font-semibold mb-3">Payouts Database</h2>
+    <div class="flex flex-wrap gap-2 mb-3 items-end">
+      <select id="payoutsDriver" class="border p-1 rounded"></select>
+      <input type="date" id="payoutsStart" class="border p-1 rounded" />
+      <input type="date" id="payoutsEnd" class="border p-1 rounded" />
+      <button onclick="loadPayouts()" class="px-4 py-1 bg-blue-600 text-white rounded">Apply</button>
+    </div>
+    <div class="overflow-auto max-h-[500px] bg-white dark:bg-gray-800 rounded shadow">
+      <table id="payoutsTable" class="min-w-max w-full text-sm">
+        <thead class="sticky top-0 bg-gray-100 dark:bg-gray-700">
+          <tr>
+            <th class="p-2 text-left cursor-pointer" onclick="sortPayouts('driver')">Driver</th>
+            <th class="p-2 text-left cursor-pointer" onclick="sortPayouts('dateCreated')">Date</th>
+            <th class="p-2 text-left">Orders</th>
+            <th class="p-2 text-left">Cash</th>
+            <th class="p-2 text-left">Fees</th>
+            <th class="p-2 text-left">Net</th>
+          </tr>
+        </thead>
+        <tbody id="payoutsBody"></tbody>
       </table>
     </div>
   </div>
@@ -265,10 +292,59 @@ document.getElementById('parcelsBody').addEventListener('dblclick',async e=>{
   const td=e.target.closest('td[data-field]');
   if(!td)return;const field=td.dataset.field;const row=td.parentNode.dataset.name;const val=prompt(`Edit ${field}`,td.textContent);if(val===null)return;td.textContent=val;const driver=document.getElementById('parcelsDriver').value;let payload={order_name:row};if(field==='deliveryStatus')payload.new_status=val;else if(field==='cashAmount')payload.cash_amount=parseFloat(val)||0;else if(field==='address'||field==='customerPhone')payload.note=val;await fetch(`/order/status?driver=${driver}`,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
 });
+
+// ----------------------- PAYOUTS DB -------------------------------
+let payoutsSortKey = 'dateCreated', payoutsSortDir = -1;
+function sortPayouts(key){
+  if(payoutsSortKey===key) payoutsSortDir*=-1; else {payoutsSortKey=key;payoutsSortDir=1;}
+  loadPayouts();
+}
+async function loadPayoutsTab(){
+  const sel=document.getElementById('payoutsDriver');
+  if(!sel.options.length){
+    const drivers=await fetch('/drivers').then(r=>r.json()).catch(()=>[]);
+    sel.innerHTML='<option value="">Select driver</option>';
+    drivers.forEach(d=>{const o=document.createElement('option');o.value=d;o.textContent=d;sel.appendChild(o);});
+    if(drivers.length) sel.value=drivers[0];
+  }
+  loadPayouts();
+}
+async function loadPayouts(){
+  const driver=document.getElementById('payoutsDriver').value;
+  if(!driver){document.getElementById('payoutsBody').innerHTML='';return;}
+  let data=await fetch(`/payouts?driver=${driver}`).then(r=>r.json()).catch(()=>[]);
+  const sd=document.getElementById('payoutsStart').value;
+  const ed=document.getElementById('payoutsEnd').value;
+  data=data.filter(p=>{
+    if(sd&&p.dateCreated<sd) return false;
+    if(ed&&p.dateCreated>ed+' 23:59:59') return false;
+    return true;
+  });
+  data.sort((a,b)=>{
+    let v1=a[payoutsSortKey],v2=b[payoutsSortKey];
+    if(payoutsSortKey!=='driver'){v1=v1||'';v2=v2||'';}
+    return v1>v2?payoutsSortDir:-payoutsSortDir;
+  });
+  const body=document.getElementById('payoutsBody');
+  body.innerHTML='';
+  data.forEach(p=>{
+    const tr=document.createElement('tr');
+    tr.dataset.id=p.payoutId;
+    tr.innerHTML=`<td class="p-2" data-field="driver">${driver}</td><td class="p-2" data-field="dateCreated">${p.dateCreated}</td><td class="p-2" data-field="orders">${p.orders}</td><td class="p-2" data-field="totalCash">${p.totalCash}</td><td class="p-2" data-field="totalFees">${p.totalFees}</td><td class="p-2" data-field="totalPayout">${p.totalPayout}</td>`;
+    body.appendChild(tr);
+  });
+}
+document.getElementById('payoutsBody').addEventListener('dblclick',async e=>{
+  const td=e.target.closest('td[data-field]');
+  if(!td)return;const field=td.dataset.field;const id=td.parentNode.dataset.id;const val=prompt(`Edit ${field}`,td.textContent);if(val===null)return;td.textContent=val;const driver=document.getElementById('payoutsDriver').value;let payload={};
+  if(field==='totalCash')payload.total_cash=parseFloat(val)||0;else if(field==='totalFees')payload.total_fees=parseFloat(val)||0;else if(field==='totalPayout')payload.total_payout=parseFloat(val)||0;else if(field==='orders')payload.orders=val;else if(field==='dateCreated')payload.date_created=val;await fetch(`/payout/${id}?driver=${driver}`,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+});
 document.addEventListener('DOMContentLoaded',()=>{
   const {start,end}=computeDefaultDates();
   document.getElementById('startDate').value=start;
   document.getElementById('endDate').value=end;
+  document.getElementById('payoutsStart').value=start;
+  document.getElementById('payoutsEnd').value=end;
   loadOverview();
 });
 </script>


### PR DESCRIPTION
## Summary
- introduce `PayoutUpdate` model and a `/payout/{id}` PUT endpoint
- update `admin_dashboard.html` with a new *Payouts DB* tab
- allow inline editing and sorting for payouts
- tweak fonts and dark mode

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687262c3034c83218cf5aab9ae717a4b