### PR TITLE
Improve driver dashboard visuals

### DIFF
--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -5,19 +5,21 @@
   <meta charset="UTF-8">
   <title>Delivery Management</title>
   <link rel="icon" type="image/png" href="favicon.png" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <script src="https://unpkg.com/html5-qrcode"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0/dist/chartjs-plugin-datalabels.min.js"></script>
   <style>
     *{margin:0;padding:0;box-sizing:border-box}
-    body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Arial,sans-serif;background:linear-gradient(to bottom,#f5f7fa,#e2e8f0);color:#333;line-height:1.6;min-height:100vh;overflow-x:hidden;scroll-behavior:smooth}
+    body{font-family:'Inter','Poppins',sans-serif;background:linear-gradient(to bottom,#f5f7fa,#e2e8f0);color:#333;line-height:1.6;min-height:100vh;overflow-x:hidden;scroll-behavior:smooth}
     .top-header{background:white;text-align:center;padding:0.5rem 1rem;box-shadow:0 2px 4px rgba(0,0,0,0.05)}
     .main-header{background:linear-gradient(135deg,#004aad,#0066cc);color:white;padding:1rem;text-align:center;box-shadow:0 2px 10px rgba(0,0,0,0.1)}
     .logo-icon{width:120px;height:auto;margin:0 auto;display:block}
-    .driver-info{margin-top:0.3rem;font-weight:600;display:flex;justify-content:center;gap:0.5rem;align-items:center}
+    .driver-info{margin-top:0.3rem;font-weight:600;display:flex;justify-content:center;gap:0.8rem;align-items:center}
+    .driver-avatar{width:40px;height:40px;border-radius:50%;background:#e0e0e0;color:#004aad;font-weight:bold;display:flex;align-items:center;justify-content:center;font-size:1.1rem}
     .driver-name{font-size:1.2rem;text-transform:uppercase}
     .current-time{font-size:1rem}
-    .delivery-rate{font-size:1rem;font-weight:bold}
+    .delivery-rate{font-size:1.4rem;font-weight:bold}
     .nav-tabs{display:flex;background:white;border-bottom:2px solid #e1e8ed;position:sticky;top:0;z-index:100}
     .nav-tab{flex:1;padding:1rem;text-align:center;cursor:pointer;border:none;background:white;font-size:1rem;font-weight:600;color:#666;transition:all 0.3s ease}
     .nav-tab.active{color:#004aad;border-bottom:3px solid #004aad;background:#f8faff}
@@ -102,8 +104,12 @@
     .summary-item{text-align:center}
     .summary-label{font-size:0.9rem;opacity:0.9;margin-bottom:0.5rem}
     .summary-value{font-size:2rem;font-weight:bold}
-    .summary-rects{display:flex;flex-wrap:wrap;gap:0.5rem;justify-content:center;margin-top:1rem}
-    .summary-rect{flex:1 1 80px;padding:0.4rem 0.6rem;background:#f8faff;border-radius:6px;text-align:center;font-weight:bold;font-size:0.9rem}
+    .summary-rects{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:0.5rem;margin-top:1rem}
+    .summary-rect{padding:0.6rem 0.8rem;border-radius:12px;text-align:center;font-weight:bold;font-size:0.9rem;box-shadow:0 2px 6px rgba(0,0,0,0.1);transition:transform 0.2s}
+    .summary-rect:hover{transform:translateY(-2px)}
+    .stat-card{background:rgba(255,255,255,0.7);backdrop-filter:blur(4px);padding:1rem;border-radius:1rem;box-shadow:0 4px 10px rgba(0,0,0,0.1);text-align:center}
+    .stat-card-title{color:#555;font-size:0.9rem;margin-bottom:0.3rem}
+    .stat-card-value{font-size:1.6rem;font-weight:bold;color:#1e88e5}
     .payout-card{background:white;border-radius:12px;padding:1.5rem;box-shadow:0 2px 10px rgba(0,0,0,0.1);border-left:4px solid #4caf50}
     .payout-card.paid{border-left-color:#2196f3;opacity:0.8}
     .payout-header{display:flex;justify-content:between;align-items:center;margin-bottom:1rem;flex-wrap:wrap;gap:1rem}
@@ -138,6 +144,7 @@
       .order-details{grid-template-columns:1fr}
       .summary-grid{grid-template-columns:1fr}
       .payout-details{grid-template-columns:1fr}
+      .delivery-rate{font-size:1.2rem}
     }
   </style>
 </head>
@@ -148,6 +155,7 @@
   <div class="main-header">
     <h1>📦 Delivery Management</h1>
     <div class="driver-info">
+      <div id="driverAvatar" class="driver-avatar"></div>
       <span id="driverName" class="driver-name"></span>
       <span id="currentTime" class="current-time"></span>
       <span id="deliveryRate" class="delivery-rate"></span>
@@ -261,6 +269,7 @@
       // Display driver name and current time in header
       const driverNameEl = document.getElementById('driverName');
       const currentTimeEl = document.getElementById('currentTime');
+      const driverAvatarEl = document.getElementById('driverAvatar');
       function updateTime(){
         const now = new Date();
         const timeStr = now.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
@@ -268,6 +277,9 @@
       }
       if (driverNameEl) {
         driverNameEl.textContent = driver_id.toUpperCase();
+      }
+      if(driverAvatarEl){
+        driverAvatarEl.textContent = driver_id.slice(0,2).toUpperCase();
       }
       updateTime();
       setInterval(updateTime, 60000);
@@ -297,6 +309,19 @@
   const deliveryStatuses = ['Dispatched','Livré','En cours','Pas de réponse 1','Pas de réponse 2','Pas de réponse 3','Annulé','Refusé','Rescheduled','Returned'];
   const formatMoney = n => (parseFloat(n) || 0).toFixed(2).replace('.', ',');
 
+  function animateValue(id,start,end,duration){
+    const el=document.getElementById(id);if(!el)return;const s=Number(start),e=Number(end);const suf=el.dataset.suffix||'';let startTs=null;
+    function step(ts){if(!startTs)startTs=ts;const p=Math.min((ts-startTs)/duration,1);el.textContent=(s+(e-s)*p).toFixed(suf?2:0)+suf;if(p<1)requestAnimationFrame(step);}requestAnimationFrame(step);
+  }
+
+  const centerTextPlugin={
+    id:'centerText',
+    afterDraw(chart, args, opts){
+      if(!opts||!opts.text)return;const {ctx,chartArea:{left,right,top,bottom}}=chart;ctx.save();ctx.font='bold 1.2rem Poppins,sans-serif';ctx.fillStyle='#333';ctx.textAlign='center';ctx.textBaseline='middle';ctx.fillText(opts.text,(left+right)/2,(top+bottom)/2);ctx.restore();
+    }
+  };
+  Chart.register(centerTextPlugin);
+
   /* ---------- Charts ---------- */
   let ordersChart = null;
   let statsChart  = null;
@@ -320,21 +345,24 @@
         labels: ['Livré','Annulé/Refusé/Retourné','Dispatched','En cours'],
         datasets: [{
           data: [delivered, failed, dispatched, inprog],
-          backgroundColor: ['#4caf50','#f44336','#2196f3','#ff9800'],
-          borderWidth: 0
+          backgroundColor: ['#a5d6a7','#ef9a9a','#90caf9','#ffe082'],
+          borderWidth: 0,
+          hoverOffset: 8
         }]
       },
       options: {
-        cutout: '65%',
+        cutout: '70%',
         plugins: {
-          legend: { position: 'bottom' },
+          legend: { position: 'bottom', labels:{usePointStyle:true} },
           datalabels: {
             color: '#000',
+            font:{weight:'bold'},
             formatter: (v,ctx) => {
               const t = ctx.chart.data.datasets[0].data.reduce((a,b)=>a+b,0);
               return t? `${v}\n(${((v/t)*100).toFixed(1)}%)` : '';
             }
-          }
+          },
+          centerText:{ text:`📦 ${orders.length} Total` }
         },
         maintainAspectRatio: false
       }
@@ -354,21 +382,24 @@
         labels: ['Livré','Annulé/Refusé/Retourné','Dispatched','En cours'],
         datasets: [{
           data: [data.delivered, data.failed, data.dispatched, data.inprog],
-          backgroundColor: ['#4caf50','#f44336','#2196f3','#ff9800'],
-          borderWidth: 0
+          backgroundColor: ['#a5d6a7','#ef9a9a','#90caf9','#ffe082'],
+          borderWidth: 0,
+          hoverOffset: 8
         }]
       },
       options: {
-        cutout: '65%',
+        cutout: '70%',
         plugins: {
-          legend: { position: 'bottom' },
+          legend: { position: 'bottom', labels:{usePointStyle:true} },
           datalabels: {
             color: '#000',
+            font:{weight:'bold'},
             formatter: (v,ctx) => {
               const t = ctx.chart.data.datasets[0].data.reduce((a,b)=>a+b,0);
               return t? `${v}\n(${((v/t)*100).toFixed(1)}%)` : '';
             }
-          }
+          },
+          centerText:{ text:`📦 ${data.total || 0} Total` }
         },
         maintainAspectRatio: false
       }
@@ -378,7 +409,7 @@
   function updateDeliveryRateDisplay(rate){
     const el = document.getElementById('deliveryRate');
     if(!el) return;
-    el.textContent = rate.toFixed(0)+'%';
+    el.textContent = `Success Rate: ${rate.toFixed(0)}% ✅`;
     el.style.color = rate >= 80 ? '#4caf50' : rate >= 60 ? '#ffb300' : '#f44336';
   }
 
@@ -529,11 +560,11 @@
       <div class="order-summary">
         <h2 style="text-align:center;margin-bottom:1rem;">📋 Orders Summary</h2>
         <div class="summary-rects">
-          <div class="summary-rect" style="background:#2196f3;color:#fff;">Active<br>${orders.length}</div>
-          <div class="summary-rect" style="background:#ff9800;color:#fff;">PDR1<br>${counts['Pas de réponse 1']}</div>
-          <div class="summary-rect" style="background:#ffb300;color:#fff;">PDR2<br>${counts['Pas de réponse 2']}</div>
-          <div class="summary-rect" style="background:#ff7043;color:#fff;">PDR3<br>${counts['Pas de réponse 3']}</div>
-          <div class="summary-rect" style="background:#9c27b0;color:#fff;">Resched<br>${counts['Rescheduled']}</div>
+          <div class="summary-rect" style="background:#2196f3;color:#fff;">🚚 Active<br>${orders.length}</div>
+          <div class="summary-rect" style="background:#ff9800;color:#fff;">⏳ PDR1<br>${counts['Pas de réponse 1']}</div>
+          <div class="summary-rect" style="background:#ffb300;color:#000;">⏳ PDR2<br>${counts['Pas de réponse 2']}</div>
+          <div class="summary-rect" style="background:#ff7043;color:#fff;">⏳ PDR3<br>${counts['Pas de réponse 3']}</div>
+          <div class="summary-rect" style="background:#9c27b0;color:#fff;">🔄 Resched<br>${counts['Rescheduled']}</div>
         </div>
       </div>`;
 
@@ -769,12 +800,13 @@
       <div class="payout-summary">
         <h2 style="text-align:center;margin-bottom:1rem;">💰 Payout Summary</h2>
         <div class="summary-grid">
-          <div class="summary-item"><div class="summary-label">Total Cash</div><div class="summary-value">${formatMoney(totalCash)} DH</div></div>
-          <div class="summary-item"><div class="summary-label">Total Fees</div><div class="summary-value">${formatMoney(totalFees)} DH</div></div>
-          <div class="summary-item"><div class="summary-label">Net Payout</div><div class="summary-value">${formatMoney(totalPayout)} DH</div></div>
-          <div class="summary-item"><div class="summary-label">Pending</div><div class="summary-value">${pendingCnt}</div></div>
+          <div class="stat-card"><div class="stat-card-title">💵 Total Cash</div><div class="stat-card-value" id="pyCash">0</div></div>
+          <div class="stat-card"><div class="stat-card-title">📈 Total Fees</div><div class="stat-card-value" id="pyFees">0</div></div>
+          <div class="stat-card"><div class="stat-card-title">💰 Net Payout</div><div class="stat-card-value" id="pyNet">0</div></div>
+          <div class="stat-card"><div class="stat-card-title">⏳ Pending</div><div class="stat-card-value" id="pyPend">0</div></div>
         </div>
       </div>`;
+
 
     payouts.forEach(p=>{
       const paid = p.status==='paid'||p.status==='Paid';
@@ -800,6 +832,10 @@
       </div>`;
     });
     c.innerHTML = h;
+    animateValue('pyCash',0,totalCash,800);
+    animateValue('pyFees',0,totalFees,800);
+    animateValue('pyNet',0,totalPayout,800);
+    animateValue('pyPend',0,pendingCnt,800);
   }
 
   function markPayoutPaid(payoutId){
@@ -849,20 +885,27 @@
       <div class="payout-summary">
         <h2 style="text-align:center;margin-bottom:1rem;">📊 Stats Summary</h2>
         <div class="summary-grid">
-          <div class="summary-item"><div class="summary-label">Total Orders</div><div class="summary-value">${st.totalOrders}</div></div>
-          <div class="summary-item"><div class="summary-label">Delivered</div><div class="summary-value">${st.delivered}</div></div>
-          <div class="summary-item"><div class="summary-label">Returned/Cancelled/Refused</div><div class="summary-value">${st.returned}</div></div>
-          <div class="summary-item"><div class="summary-label">Collected</div><div class="summary-value">${formatMoney(st.totalCollect)} DH</div></div>
-          <div class="summary-item"><div class="summary-label">Fees Earned</div><div class="summary-value">${formatMoney(st.totalFees)} DH</div></div>
-          <div class="summary-item"><div class="summary-label">Delivery Rate</div><div class="summary-value">${(st.deliveryRate||0).toFixed(1)}%</div></div>
+          <div class="stat-card"><div class="stat-card-title">📦 Total Orders</div><div class="stat-card-value" id="stTotal">0</div></div>
+          <div class="stat-card"><div class="stat-card-title">✅ Delivered</div><div class="stat-card-value" id="stDeliv">0</div></div>
+          <div class="stat-card"><div class="stat-card-title">❌ Returned</div><div class="stat-card-value" id="stRet">0</div></div>
+          <div class="stat-card"><div class="stat-card-title">💰 Collected</div><div class="stat-card-value" id="stCash" data-suffix=" DH">0</div></div>
+          <div class="stat-card"><div class="stat-card-title">📈 Fees Earned</div><div class="stat-card-value" id="stFees" data-suffix=" DH">0</div></div>
+          <div class="stat-card"><div class="stat-card-title">🚚 Delivery Rate</div><div class="stat-card-value" id="stRate" data-suffix="%">0</div></div>
         </div>
       </div>`;
     document.getElementById('statsContainer').innerHTML = h;
+    animateValue('stTotal',0,st.totalOrders,800);
+    animateValue('stDeliv',0,st.delivered,800);
+    animateValue('stRet',0,st.returned,800);
+    animateValue('stCash',0,parseFloat(st.totalCollect||0),800);
+    animateValue('stFees',0,parseFloat(st.totalFees||0),800);
+    animateValue('stRate',0,(st.deliveryRate||0).toFixed(0),800);
     buildStatsChart({
       delivered: st.delivered || 0,
       failed: st.returned || 0,
       dispatched,
-      inprog
+      inprog,
+      total: st.totalOrders || 0
     });
   }
 


### PR DESCRIPTION
## Summary
- add Inter/Poppins fonts and pastel color scheme
- show driver avatar and highlight success rate
- upgrade donut charts with center labels and datalabels
- convert stats and payouts summaries to animated cards
- style order summary badges

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6872f641b7208321bc2d112c9963f794