### PR TITLE
Support city-based driver fees

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -38,6 +38,16 @@ class Merchant(Base):
     name = Column(String)
     password_hash = Column(String)
 
+
+class CityFee(Base):
+    __tablename__ = "city_fees"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    merchant_id = Column(String, ForeignKey("merchants.id"), index=True)
+    city = Column(String, index=True)
+    fee = Column(Float)
+
+    merchant = relationship("Merchant")
+
 class Order(Base):
     __tablename__ = "orders"
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -48,6 +58,7 @@ class Order(Base):
     customer_name = Column(String)
     customer_phone = Column(String)
     address = Column(Text)
+    city = Column(String)
     tags = Column(String)
     fulfillment = Column(String)
     order_status = Column(String)
@@ -127,6 +138,15 @@ async def init_db() -> None:
         )
         if not result.first():
             await conn.execute(text("ALTER TABLE orders ADD COLUMN merchant_id VARCHAR"))
+
+        result = await conn.execute(
+            text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name='orders' AND column_name='city'"
+            )
+        )
+        if not result.first():
+            await conn.execute(text("ALTER TABLE orders ADD COLUMN city VARCHAR"))
 
     default_drivers = ["abderrehman", "anouar", "mohammed", "nizar"]
     default_merchants = [

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -44,6 +44,7 @@ from .db import (
     Payout,
     EmployeeLog,
     Merchant,
+    CityFee,
 )
 from passlib.hash import bcrypt
 
@@ -128,6 +129,11 @@ class PayoutUpdate(BaseModel):
     total_fees: Optional[float] = None
     total_payout: Optional[float] = None
     date_created: Optional[str] = None
+
+
+class CityFeeIn(BaseModel):
+    city: str
+    fee: float
 
 
 # ───────────────────────────────────────────────────────────────
@@ -302,6 +308,59 @@ async def merchant_login(merchant_id: str = Form(...), password: str = Form(...)
         return {"success": True}
 
 
+@app.get("/merchant/{merchant_id}/fees", tags=["merchant"])
+async def list_fees(merchant_id: str):
+    """Return all city fees for a merchant."""
+    async for session in get_session():
+        result = await session.execute(
+            select(CityFee).where(CityFee.merchant_id == merchant_id)
+        )
+        fees = [
+            {"city": f.city, "fee": f.fee}
+            for f in result.scalars().all()
+        ]
+        return fees
+
+
+@app.post("/merchant/{merchant_id}/fees", tags=["merchant"])
+async def set_fee(merchant_id: str, payload: CityFeeIn):
+    """Create or update a city fee for a merchant."""
+    async for session in get_session():
+        fee = await session.scalar(
+            select(CityFee).where(
+                CityFee.merchant_id == merchant_id,
+                CityFee.city.ilike(payload.city),
+            )
+        )
+        if fee:
+            fee.fee = payload.fee
+        else:
+            fee = CityFee(
+                merchant_id=merchant_id,
+                city=payload.city,
+                fee=payload.fee,
+            )
+            session.add(fee)
+        await session.commit()
+        return {"success": True}
+
+
+@app.delete("/merchant/{merchant_id}/fees/{city}", tags=["merchant"])
+async def delete_fee(merchant_id: str, city: str):
+    async for session in get_session():
+        fee = await session.scalar(
+            select(CityFee).where(
+                CityFee.merchant_id == merchant_id,
+                CityFee.city.ilike(city),
+            )
+        )
+        if not fee:
+            raise HTTPException(status_code=404, detail="Fee not found")
+        await session.delete(fee)
+        await session.commit()
+        return {"success": True}
+
+
 @app.get("/drivers")
 async def list_drivers():
     async for session in get_session():
@@ -335,6 +394,22 @@ def calculate_driver_fee(tags: str) -> int:
     return (
         EXCHANGE_DELIVERY_FEE if "ch" in (tags or "").lower() else NORMAL_DELIVERY_FEE
     )
+
+
+async def driver_fee_for_order(
+    session: AsyncSession, merchant_id: str, city: str, tags: str
+) -> float:
+    """Return the fee for a given merchant/city combo with fallback."""
+    result = await session.execute(
+        select(CityFee.fee).where(
+            CityFee.merchant_id == merchant_id,
+            CityFee.city.ilike(city),
+        )
+    )
+    fee = result.scalar()
+    if fee is not None:
+        return fee
+    return calculate_driver_fee(tags)
 
 
 def get_primary_display_tag(tags: str) -> str:
@@ -592,6 +667,7 @@ async def scan(
             "closed" if (chosen_order and chosen_order.get("cancelled_at")) else "open"
         )
         customer_name = phone = address = ""
+        city = ""
         cash_amount = 0.0
         result_msg = "❌ Not found"
 
@@ -621,10 +697,11 @@ async def scan(
                         ],
                     )
                 )
+                city = sa.get("city", "")
 
         now_ts = dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         scan_day = dt.datetime.now().strftime("%Y-%m-%d")
-        driver_fee = calculate_driver_fee(tags)
+        driver_fee = await driver_fee_for_order(session, merchant, city, tags)
 
         order = Order(
             driver_id=driver,
@@ -634,6 +711,7 @@ async def scan(
             customer_name=customer_name,
             customer_phone=phone,
             address=address,
+            city=city,
             tags=tags,
             fulfillment=fulfillment,
             order_status=order_status,
@@ -889,7 +967,9 @@ async def update_order_status(
             order.follow_log = payload.follow_log
 
         if payload.new_status == "Livré" and prev_status != "Livré":
-            driver_fee = calculate_driver_fee(order.tags)
+            driver_fee = await driver_fee_for_order(
+                session, merchant, order.city or "", order.tags
+            )
             cash_amt = payload.cash_amount or (order.cash_amount or 0)
             payout_id = await add_to_payout(
                 session, driver, payload.order_name, cash_amt, driver_fee


### PR DESCRIPTION
## Summary
- add `CityFee` table and reference in Order
- add `city` field to orders and update DB init
- allow merchants to manage fees per city
- calculate driver fee using city fee when available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6873060638c883219ea38c6368ce0fa6