### PR TITLE
Add merchant dashboard and API endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,13 +16,24 @@ from dotenv import load_dotenv
 load_dotenv()
 import os
 import json
+import csv
+import io
 import datetime as dt
 from typing import List, Optional
 from datetime import timezone
 import httpx
-from fastapi import FastAPI, HTTPException, BackgroundTasks, Query, WebSocket, WebSocketDisconnect
+from fastapi import (
+    FastAPI,
+    HTTPException,
+    BackgroundTasks,
+    Query,
+    WebSocket,
+    WebSocketDisconnect,
+    Form,
+    UploadFile,
+    File,
+)
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi import Form
 from cachetools import TTLCache
 from fastapi.responses import HTMLResponse, FileResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
@@ -359,6 +370,151 @@ async def delete_fee(merchant_id: str, city: str):
         await session.delete(fee)
         await session.commit()
         return {"success": True}
+
+
+@app.get("/merchant/orders", tags=["merchant"])
+async def merchant_orders(merchant_id: str = Query(...)):
+    """Return all orders for a merchant across drivers."""
+    async for session in get_session():
+        result = await session.execute(
+            select(Order).where(Order.merchant_id == merchant_id)
+        )
+        rows = result.scalars().all()
+        orders: list[dict] = []
+        for o in rows:
+            orders.append(
+                {
+                    "timestamp": o.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+                    "driver": o.driver_id,
+                    "orderName": o.order_name,
+                    "customerName": o.customer_name,
+                    "customerPhone": o.customer_phone,
+                    "address": o.address,
+                    "tags": o.tags,
+                    "deliveryStatus": o.delivery_status or "Dispatched",
+                    "notes": o.notes,
+                    "driverNotes": o.driver_notes,
+                    "scheduledTime": o.scheduled_time,
+                    "scanDate": o.scan_date,
+                    "cashAmount": o.cash_amount or 0,
+                    "driverFee": o.driver_fee or 0,
+                    "payoutId": o.payout_id,
+                    "statusLog": o.status_log,
+                    "commLog": o.comm_log,
+                    "followLog": o.follow_log,
+                }
+            )
+        orders.sort(key=lambda r: r["timestamp"])
+        return orders
+
+
+@app.get("/merchant/payouts", tags=["merchant"])
+async def merchant_payouts(merchant_id: str = Query(...)):
+    """Return payout info for a merchant grouped by driver."""
+    async for session in get_session():
+        result = await session.execute(
+            select(Order).where(
+                Order.merchant_id == merchant_id, Order.payout_id.is_not(None)
+            )
+        )
+        orders = result.scalars().all()
+        payouts: dict[tuple[str, str], dict] = {}
+        for o in orders:
+            payout = await session.scalar(
+                select(Payout).where(Payout.payout_id == o.payout_id)
+            )
+            if not payout:
+                continue
+            key = (payout.payout_id, o.driver_id)
+            p = payouts.get(key)
+            if not p:
+                p = {
+                    "payoutId": payout.payout_id,
+                    "driver": o.driver_id,
+                    "dateCreated": payout.date_created.strftime("%Y-%m-%d %H:%M:%S"),
+                    "status": payout.status or "pending",
+                    "datePaid": (
+                        payout.date_paid.strftime("%Y-%m-%d %H:%M:%S")
+                        if payout.date_paid
+                        else ""
+                    ),
+                    "orders": [],
+                    "totalCash": 0.0,
+                    "totalFees": 0.0,
+                    "totalPayout": 0.0,
+                }
+                payouts[key] = p
+            p["orders"].append(o.order_name)
+            p["totalCash"] += o.cash_amount or 0
+            p["totalFees"] += o.driver_fee or 0
+            p["totalPayout"] = p["totalCash"] - p["totalFees"]
+        return [
+            {
+                **p,
+                "orders": ", ".join(p["orders"]),
+            }
+            for p in payouts.values()
+        ]
+
+
+@app.post("/merchant/upload-orders", tags=["merchant"])
+async def upload_orders(
+    merchant_id: str = Form(...),
+    file: UploadFile | None = File(None),
+    orders: str | None = Form(None),
+):
+    """Upload new orders for a merchant via CSV file or JSON list."""
+    if not file and not orders:
+        raise HTTPException(status_code=400, detail="Provide file or orders data")
+
+    order_rows = []
+    if file:
+        content = (await file.read()).decode()
+        reader = csv.DictReader(io.StringIO(content))
+        for row in reader:
+            order_rows.append(row)
+    elif orders:
+        try:
+            parsed = json.loads(orders)
+            if isinstance(parsed, dict):
+                order_rows.append(parsed)
+            else:
+                order_rows.extend(parsed)
+        except Exception:
+            raise HTTPException(status_code=400, detail="Invalid orders JSON")
+
+    added = 0
+    async for session in get_session():
+        for row in order_rows:
+            driver_id = (row.get("driver_id") or row.get("driver") or "").strip()
+            order_name = (row.get("order_name") or row.get("order") or "").strip()
+            if not driver_id or not order_name:
+                continue
+            order = Order(
+                driver_id=driver_id,
+                merchant_id=merchant_id,
+                order_name=order_name,
+                customer_name=row.get("customer_name"),
+                customer_phone=row.get("customer_phone"),
+                address=row.get("address"),
+                city=row.get("city"),
+                tags=row.get("tags"),
+                cash_amount=safe_float(row.get("cash_amount")),
+                delivery_status="Dispatched",
+                scan_date=dt.datetime.utcnow().strftime("%Y-%m-%d"),
+            )
+            session.add(order)
+            added += 1
+        await session.commit()
+
+        for row in order_rows:
+            drv = row.get("driver_id") or row.get("driver")
+            if drv:
+                key = f"{merchant_id}:{drv}"
+                await cache_delete("orders", key)
+                await cache_delete("archive", key)
+
+        return {"success": True, "added": added}
 
 
 @app.get("/drivers")

--- a/backend/app/static/merchant_dashboard.html
+++ b/backend/app/static/merchant_dashboard.html
@@ -5,11 +5,64 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Merchant Dashboard</title>
   <style>
-    body{font-family:sans-serif;background:linear-gradient(to bottom,#f5f7fa,#e2e8f0);min-height:100vh;margin:0;padding:1rem;text-align:center;}
+    body{font-family:sans-serif;background:#f5f7fa;margin:0;padding:1rem;}
+    h1{text-align:center;color:#004aad;margin-bottom:1rem;}
+    table{width:100%;border-collapse:collapse;margin-top:0.5rem;}
+    th,td{border:1px solid #ddd;padding:0.5rem;text-align:left;}
+    th{background:#f0f0f0;}
+    .summary{display:flex;gap:1rem;justify-content:center;margin:1rem 0;flex-wrap:wrap;}
+    .summary div{background:white;padding:0.6rem 1rem;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1);}  
   </style>
 </head>
 <body>
-  <h1 style="color:#004aad;margin-bottom:1rem;">Merchant Dashboard</h1>
-  <p>Welcome!</p>
+  <h1>Merchant Dashboard</h1>
+  <div class="summary" id="stats"></div>
+  <h2>Orders</h2>
+  <table id="ordersTable">
+    <thead><tr><th>Order</th><th>Driver</th><th>Status</th><th>Cash</th></tr></thead>
+    <tbody></tbody>
+  </table>
+  <h2>Payouts</h2>
+  <table id="payoutsTable">
+    <thead><tr><th>Payout</th><th>Driver</th><th>Cash</th><th>Fees</th><th>Net</th><th>Status</th></tr></thead>
+    <tbody></tbody>
+  </table>
+<script>
+const params=new URLSearchParams(location.search);
+const merchant=params.get('merchant');
+if(!merchant){document.body.innerHTML='<p>Missing merchant id</p>';throw new Error('no id');}
+let orders=[];
+async function loadOrders(){
+  const r=await fetch('/merchant/orders?merchant_id='+merchant);
+  orders=await r.json();
+  const tbody=document.querySelector('#ordersTable tbody');
+  tbody.innerHTML='';
+  orders.forEach(o=>{
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${o.orderName}</td><td>${o.driver}</td><td>${o.deliveryStatus}</td><td>${o.cashAmount||0}</td>`;
+    tbody.appendChild(tr);
+  });
+  updateStats();
+}
+function updateStats(){
+  const total=orders.length;
+  const delivered=orders.filter(o=>o.deliveryStatus==='Livré').length;
+  const returned=orders.filter(o=>['Returned','Annulé','Refusé'].includes(o.deliveryStatus)).length;
+  const cash=orders.filter(o=>o.deliveryStatus==='Livré').reduce((s,o)=>s+(o.cashAmount||0),0);
+  document.getElementById('stats').innerHTML=`<div>Total: ${total}</div><div>Delivered: ${delivered}</div><div>Returned: ${returned}</div><div>Cash: ${cash}</div>`;
+}
+async function loadPayouts(){
+  const r=await fetch('/merchant/payouts?merchant_id='+merchant);
+  const payouts=await r.json();
+  const tbody=document.querySelector('#payoutsTable tbody');
+  tbody.innerHTML='';
+  payouts.forEach(p=>{
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${p.payoutId}</td><td>${p.driver}</td><td>${p.totalCash}</td><td>${p.totalFees}</td><td>${p.totalPayout}</td><td>${p.status}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+document.addEventListener('DOMContentLoaded',()=>{loadOrders();loadPayouts();});
+</script>
 </body>
 </html>

--- a/backend/app/static/merchant_login.html
+++ b/backend/app/static/merchant_login.html
@@ -25,7 +25,13 @@ function login(){
   const id=document.getElementById('merchantId').value.trim();
   const pw=document.getElementById('merchantPassword').value.trim();
   fetch('/merchant/login',{method:'POST',body:new URLSearchParams({merchant_id:id,password:pw})})
-    .then(r=>r.ok?location.href='/static/merchant_dashboard.html':alert('Invalid credentials'));
+    .then(r=>{
+      if(r.ok){
+        location.href='/static/merchant_dashboard.html?merchant='+encodeURIComponent(id);
+      }else{
+        alert('Invalid credentials');
+      }
+    });
 }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- implement `/merchant/orders`, `/merchant/payouts`, and `/merchant/upload-orders` API endpoints
- enhance merchant login to pass merchant id
- create functional merchant dashboard listing orders, payouts and stats

## Testing
- `pytest -q` *(fails: could not install fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68730a32e540832186d5088562b14621