### PR TITLE
Improve driver dashboard UI

### DIFF
--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -13,7 +13,8 @@
     *{margin:0;padding:0;box-sizing:border-box}
     body{font-family:'Inter','Poppins',sans-serif;background:linear-gradient(to bottom,#f5f7fa,#e2e8f0);color:#333;line-height:1.6;min-height:100vh;overflow-x:hidden;scroll-behavior:smooth}
     .top-header{background:white;text-align:center;padding:0.5rem 1rem;box-shadow:0 2px 4px rgba(0,0,0,0.05)}
-    .main-header{background:linear-gradient(135deg,#004aad,#0066cc);color:white;padding:1rem;text-align:center;box-shadow:0 2px 10px rgba(0,0,0,0.1)}
+    .main-header{background:linear-gradient(135deg,#004aad,#0066cc);color:white;padding:0.5rem 1rem;text-align:center;box-shadow:0 2px 10px rgba(0,0,0,0.1)}
+    .main-header h1{font-size:1.6rem;line-height:1.2;margin-bottom:0.2rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
     .logo-icon{width:120px;height:auto;margin:0 auto;display:block}
     .driver-info{margin-top:0.3rem;font-weight:600;display:flex;justify-content:center;gap:0.8rem;align-items:center}
     .driver-avatar{width:40px;height:40px;border-radius:50%;background:#e0e0e0;color:#004aad;font-weight:bold;display:flex;align-items:center;justify-content:center;font-size:1.1rem}
@@ -285,6 +286,7 @@
       setInterval(updateTime, 60000);
       loadStatsHeader();
       applyDefaultRange();
+      loadPayouts();
 
       // Setup WebSocket for real-time updates
       const wsProtocol = location.protocol === 'https:' ? 'wss' : 'ws';
@@ -356,7 +358,8 @@
           legend: { position: 'bottom', labels:{usePointStyle:true} },
           datalabels: {
             color: '#000',
-            font:{weight:'bold'},
+            font:{weight:'bold',size:12},
+            clamp:true,
             formatter: (v,ctx) => {
               const t = ctx.chart.data.datasets[0].data.reduce((a,b)=>a+b,0);
               return t? `${v}\n(${((v/t)*100).toFixed(1)}%)` : '';
@@ -393,7 +396,8 @@
           legend: { position: 'bottom', labels:{usePointStyle:true} },
           datalabels: {
             color: '#000',
-            font:{weight:'bold'},
+            font:{weight:'bold',size:12},
+            clamp:true,
             formatter: (v,ctx) => {
               const t = ctx.chart.data.datasets[0].data.reduce((a,b)=>a+b,0);
               return t? `${v}\n(${((v/t)*100).toFixed(1)}%)` : '';


### PR DESCRIPTION
## Summary
- tweak header style for compact display
- preload payouts on page load
- reduce chart label clutter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687390f0d294832181c4d5164baba80a