### PR TITLE
Implement note removal and admin view

### DIFF
--- a/backend/app/static/admin_dashboard.html
+++ b/backend/app/static/admin_dashboard.html
@@ -105,6 +105,8 @@
         <tbody id="ordersBody"></tbody>
       </table>
     </div>
+    <h3 class="text-lg font-semibold mt-4">Delivery Notes</h3>
+    <div id="adminNotes" class="space-y-2"></div>
   </div>
 
   <!-- Parcels database tab -->
@@ -248,12 +250,13 @@ async function loadOrdersTab(){
       const b=document.createElement('button');
       b.textContent=d;
       b.className='px-3 py-1 bg-gray-200 rounded';
-      b.onclick=()=>{currentDriver=d;container.querySelectorAll('button').forEach(x=>x.classList.remove('bg-blue-600','text-white'));b.classList.add('bg-blue-600','text-white');loadOrders();};
+      b.onclick=()=>{currentDriver=d;container.querySelectorAll('button').forEach(x=>x.classList.remove('bg-blue-600','text-white'));b.classList.add('bg-blue-600','text-white');loadOrders();loadAdminNotes();};
       container.appendChild(b);
     });
     if(drivers.length) container.firstChild.click();
   }else{
     loadOrders();
+    loadAdminNotes();
   }
 }
 async function loadOrders(q){
@@ -268,14 +271,25 @@ async function loadOrders(q){
     body.appendChild(tr);
   });
 }
+async function loadAdminNotes(){
+  if(!currentDriver)return;
+  const data=await fetch(`/admin/notes?driver=${currentDriver}`).then(r=>r.json()).catch(()=>[]);
+  const c=document.getElementById('adminNotes');
+  c.innerHTML=data.map(n=>{
+    const items=n.items.map(i=>`<li>${i.orderName} - ${i.status}</li>`).join('');
+    return `<div class="border rounded"><div class="bg-gray-100 p-2 cursor-pointer" onclick="this.nextElementSibling.classList.toggle('hidden')"><strong>#${n.id}</strong> ${n.createdAt} <span class='ml-2 text-sm'>${n.summary.delivered}✓ / ${n.summary.cancelled}✖ / ${n.summary.returned}↩</span></div><div class="hidden p-2"><ul class='list-disc pl-5'>${items}</ul></div></div>`;
+  }).join('');
+}
 function searchOrders(){
   const q=document.getElementById('ordersSearchInput').value.trim();
   loadOrders(q);
+  loadAdminNotes();
 }
 async function markDelivered(name){
   if(!currentDriver)return;
   await fetch(`/order/status?driver=${currentDriver}`,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({order_name:name,new_status:'Livré'})});
   loadOrders();
+  loadAdminNotes();
 }
 
 // ----------------------- PARCELS DB -------------------------------
@@ -374,6 +388,9 @@ document.addEventListener('DOMContentLoaded',()=>{
   document.getElementById('payoutsEnd').value=end;
   const sel=document.getElementById('presetRanges');if(sel) sel.value='';
   loadOverview();
+  const wsProtocol=location.protocol==='https:'?'wss':'ws';
+  const ws=new WebSocket(`${wsProtocol}://${location.host}/ws`);
+  ws.onmessage=evt=>{try{const m=JSON.parse(evt.data);if((m.type==='note_update'||m.type==='note_approved')&&m.driver===currentDriver){loadAdminNotes();}}catch(e){}};
 });
 </script>
 </body>

--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -256,6 +256,7 @@
       const apiGet   = p        => fetch(`${API}${p}`).then(r => r.json());
       const apiPost  = (p,b={}) => fetch(`${API}${p}`, {method:"POST",headers,body:JSON.stringify(b)}).then(r => r.json());
       const apiPut   = (p,b={}) => fetch(`${API}${p}`,  {method:"PUT", headers,body:JSON.stringify(b)}).then(r => r.json());
+      const apiDelete = p => fetch(`${API}${p}`, {method:"DELETE"}).then(r => r.json());
 
       // 👇 Extract ?driver=driver1 from the URL (after login redirect)
       const urlParams = new URLSearchParams(window.location.search);
@@ -306,6 +307,9 @@
             loadOrders();
             loadPayouts();
           } else if(msg.type==='new_order' && msg.driver===driver_id){
+            loadOrders();
+          } else if((msg.type==='note_update' || msg.type==='note_approved') && msg.driver===driver_id){
+            loadNotes();
             loadOrders();
           }
         }catch(e){ console.error('ws',e); }
@@ -787,8 +791,17 @@
 
   function showNote(n){
     const c=document.getElementById('notesContainer');
-    const items = n.items.map(i=>`<li>${i.orderName} – ${formatMoney(i.cashAmount)} DH</li>`).join('');
+    const items = n.items.map(i=>{
+      const btn = n.status==='draft'?`<button onclick="removeItem(${n.id},'${i.orderName}')">❌</button>`:'';
+      return `<li>${i.orderName} – ${formatMoney(i.cashAmount)} DH ${btn}</li>`;
+    }).join('');
     c.innerHTML = `<h3>Bon de Livraison #${n.id}</h3><ul>${items}</ul><button class="scan-btn" onclick="approveNote(${n.id})">✅ Approve & Send</button><button class="scan-btn" onclick="loadNotes()">⬅️ Back</button>`;
+  }
+
+  function removeItem(noteId,order){
+    apiDelete(`/notes/${noteId}/items/${order}?driver=${driver_id}`)
+      .then(()=>openNote(noteId))
+      .catch(e=>alert('❌ '+(e.detail||e)));
   }
 
   function approveNote(id){


### PR DESCRIPTION
## Summary
- add endpoint to remove parcels from a draft delivery note
- broadcast websocket updates for note events
- expose admin `/admin/notes` listing all delivery notes
- allow drivers to revoke parcels from a note via ❌
- show delivery notes list in admin dashboard with live updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68767208b6308321a368226cd86437ca