### PR TITLE
Remove unused google packages

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,5 +12,3 @@ SQLAlchemy[asyncio]==2.0.30
 redis[hiredis]==5.0.4
 fakeredis==2.21.0
 pytest==8.2.0
-gspread==6.1.0
-google-auth==2.29.0


### PR DESCRIPTION
## Summary
- clean up backend requirements

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6876e3a8c67c8321b6057c2686875b5f