### PR TITLE
Update header and add Sheets fallback docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Delivery App Backend
+
+This project provides a FastAPI backend for the delivery app. Orders are retrieved from Shopify and optionally supplemented with data from a Google Sheet.
+
+## Google Sheets Fallback
+
+When scanning an order, the backend queries Shopify first. If Shopify does not return complete information for the order, the application can look up missing fields from a Google Sheet. The fallback is only used when the following environment variables are provided:
+
+- `GOOGLE_APPLICATION_CREDENTIALS` – path to the service account JSON credentials file with access to the sheet.
+- `SHEET_ID` – ID of the Google Sheet that contains order data (the first worksheet is used).
+
+If either variable is not set, the Google Sheets lookup is skipped and only Shopify data is used.
+
+```bash
+# Example environment setup
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/creds.json
+export SHEET_ID=your-sheet-id
+```
+
+The sheet is expected to have columns for order number, customer name, phone and address. `sheet_utils.get_order_from_sheet` handles flexible column names and returns the first matching row for the order.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,8 @@
 """
 delivery-app FastAPI backend
 ───────────────────────────
-✓ Barcode / manual scan stored in the database (+ Shopify lookup)
+✓ Barcode / manual scan stored in the database (orders looked up from Shopify)
+✓ Optionally falls back to Google Sheets when Shopify details are missing
 ✓ SQLAlchemy models for drivers, orders & payouts
 ✓ Driver-fee calculation + payout roll-up
 ✓ Order & payout queries for the mobile / web app


### PR DESCRIPTION
## Summary
- mention Shopify and optional Sheets fallback in `backend/app/main.py`
- document Google Sheets fallback configuration in `README.md`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6876ead823608321a518d0331691653b