### PR TITLE
Support # prefix in sheet order lookups

### DIFF
--- a/backend/app/sheet_utils.py
+++ b/backend/app/sheet_utils.py
@@ -34,10 +34,12 @@ def get_order_from_sheet(order_name: str) -> Optional[Dict[str, str]]:
     address_idx = find_idx(["address", "customeraddress"])
     if order_idx is None:
         return None
+    query_clean = order_name.lstrip("#").strip()
     for row in rows[1:]:
         if len(row) <= order_idx:
             continue
-        if row[order_idx].strip() == order_name:
+        row_value = row[order_idx].lstrip("#").strip()
+        if row_value == query_clean:
             def get_cell(idx):
                 return row[idx].strip() if idx is not None and idx < len(row) else ""
             return {

--- a/backend/tests/test_sheet_utils.py
+++ b/backend/tests/test_sheet_utils.py
@@ -1,0 +1,48 @@
+import os
+import types
+import sys
+import importlib
+
+# Create a dummy gspread module with minimal functionality
+class DummyWorksheet:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def get_all_values(self):
+        return self._rows
+
+class DummySheet:
+    def __init__(self, rows):
+        self.sheet1 = DummyWorksheet(rows)
+
+class DummyClient:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def open_by_key(self, key):
+        return DummySheet(self._rows)
+
+
+def make_gspread_stub(rows):
+    def service_account(filename):
+        return DummyClient(rows)
+    mod = types.SimpleNamespace(service_account=service_account)
+    return mod
+
+
+def test_lookup_strips_hash(monkeypatch):
+    rows = [
+        ["Order Number", "Customer Name"],
+        ["#1234", "Alice"],
+        ["5678", "Bob"],
+    ]
+    sys.modules['gspread'] = make_gspread_stub(rows)
+    import app.sheet_utils as sheet_utils
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "creds.json")
+    monkeypatch.setenv("SHEET_ID", "dummy")
+
+    res1 = sheet_utils.get_order_from_sheet("1234")
+    assert res1 == {"customer_name": "Alice", "customer_phone": "", "address": ""}
+
+    res2 = sheet_utils.get_order_from_sheet("#5678")
+    assert res2["customer_name"] == "Bob"


### PR DESCRIPTION
## Summary
- handle hash-prefixed order numbers in sheet lookup
- test get_order_from_sheet with and without the `#` prefix

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68775b093d1883218b2e0a3d3899669c