### PR TITLE
Add manual sheet sync for verification

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1499,6 +1499,14 @@ async def admin_verify_update(item_id: int, payload: VerificationUpdate):
         return {"success": True}
 
 
+@app.post("/admin/verify/sync", tags=["admin"])
+async def admin_verify_sync(date: str = Query(...)):
+    """Manually import verification orders from the Google Sheet."""
+    async for session in get_session():
+        await sync_verification_orders(date, session)
+        return {"success": True}
+
+
 @app.get("/admin/notes", tags=["admin"])
 async def admin_list_notes(driver: str | None = Query(None)):
     async for session in get_session():

--- a/backend/app/static/admin_dashboard.html
+++ b/backend/app/static/admin_dashboard.html
@@ -118,6 +118,7 @@
       <button onclick="changeVerifyDate(1)" class="px-2">▶</button>
       <input id="verifySearch" placeholder="Search..." class="flex-grow border p-1 rounded" />
       <button onclick="loadVerify()" class="bg-blue-600 text-white px-3 py-1 rounded">Apply</button>
+      <button onclick="syncVerify()" class="bg-green-600 text-white px-3 py-1 rounded">Sync Sheet</button>
     </div>
     <div class="overflow-auto max-h-[500px] bg-white rounded shadow">
       <table id="verifyTable" class="min-w-max w-full text-sm">
@@ -445,6 +446,12 @@ async function loadVerify(){
     if(r.verified)verified++;
   });
   document.getElementById('verifyFooter').textContent=`Total ${data.total} – Verified ${verified} – Missing ${data.missing}`;
+}
+
+async function syncVerify(){
+  const date=document.getElementById('verifyDate').value;
+  await fetch(`/admin/verify/sync?date=${date}`,{method:'POST'});
+  loadVerify();
 }
 document.getElementById('verifyBody').addEventListener('dblclick',async e=>{
   const td=e.target.closest('td[data-field]');if(!td)return;const id=td.parentNode.dataset.id;

--- a/backend/tests/test_scan_sheet.py
+++ b/backend/tests/test_scan_sheet.py
@@ -3,11 +3,19 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 import asyncio
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import importlib
+
+if os.path.exists("test.db"):
+    os.remove("test.db")
 
 # Ensure an in-memory database for tests
 os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///test.db"
 
 from app import main as app_main
+importlib.reload(app_main)
 
 class DummyResponse:
     def __init__(self, payload):


### PR DESCRIPTION
## Summary
- allow manual order verification import
- enable manual sync from admin dashboard
- adjust test helper to remove leftover DB

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: tests/test_scan_sheet.py::test_scan_uses_sheet_when_shopify_incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_687a9ff73e848321bb4c007273090736