### PR TITLE
Handle missing verification dates

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -264,7 +264,8 @@ async def sync_verification_orders(date_str: str, session: AsyncSession) -> None
         return
     created = 0
     for row in rows:
-        if row.get("order_date") != date_str:
+        row_date = row.get("order_date") or date_str
+        if row_date != date_str:
             continue
         existing = await session.scalar(
             select(VerificationOrder).where(

--- a/backend/app/sheet_utils.py
+++ b/backend/app/sheet_utils.py
@@ -122,9 +122,10 @@ def load_sheet_orders() -> List[Dict[str, str]]:
             continue
         order["order_name"] = row[indices["order"]].strip()
         if indices["date"] is not None and len(row) > indices["date"]:
-            order["order_date"] = row[indices["date"]].strip()
+            value = row[indices["date"]].strip()
+            order["order_date"] = value or None
         else:
-            order["order_date"] = ""
+            order["order_date"] = None
         order["customer_name"] = row[indices["name"]].strip() if indices["name"] is not None and len(row)>indices["name"] else ""
         order["customer_phone"] = row[indices["phone"]].strip() if indices["phone"] is not None and len(row)>indices["phone"] else ""
         order["address"] = row[indices["address"]].strip() if indices["address"] is not None and len(row)>indices["address"] else ""

--- a/backend/tests/test_sheet_utils.py
+++ b/backend/tests/test_sheet_utils.py
@@ -61,3 +61,31 @@ def test_lookup_strips_hash(monkeypatch):
     res2 = sheet_utils.get_order_from_sheet("#5678")
     assert res2["customer_name"] == "Bob"
     assert calls[0] == ("dict", {"dummy": "yes"})
+
+
+def test_load_sheet_orders_missing_date(monkeypatch):
+    rows = [
+        ["Order", "Customer"],
+        ["#111", "Alice"],
+    ]
+    calls = []
+    sys.modules['gspread'] = make_gspread_stub(rows, calls)
+    import app.sheet_utils as sheet_utils
+    importlib.reload(sheet_utils)
+    cred_json = '{"dummy": "yes"}'
+    b64 = base64.b64encode(cred_json.encode()).decode()
+    monkeypatch.setenv("GOOGLE_CREDENTIALS_B64", b64)
+    monkeypatch.setenv("VERIFICATION_SHEET_ID", "dummy")
+
+    orders = sheet_utils.load_sheet_orders()
+    assert orders == [
+        {
+            "order_name": "#111",
+            "order_date": None,
+            "customer_name": "Alice",
+            "customer_phone": "",
+            "address": "",
+            "city": "",
+            "cod_total": "",
+        }
+    ]


### PR DESCRIPTION
## Summary
- default missing sheet dates to requested date
- update load_sheet_orders to return `None` for missing dates
- cover missing date rows in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bcaa36e488321b96fe4da6dda8767