### PR TITLE
Add verification table fallback on scan

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -699,6 +699,19 @@ async def scan(
                 phone = phone or sheet_data.get("customer_phone", "")
                 address = address or sheet_data.get("address", "")
 
+        # As a final fallback, look for the order in the verification table
+        # to populate any missing details
+        if not customer_name or not phone or not address:
+            vo = await session.scalar(
+                select(VerificationOrder)
+                .where(VerificationOrder.order_name == order_number)
+                .order_by(VerificationOrder.id.desc())
+            )
+            if vo:
+                customer_name = customer_name or vo.customer_name or ""
+                phone = phone or vo.customer_phone or ""
+                address = address or vo.address or ""
+
         now_ts = dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         scan_day = dt.datetime.now().strftime("%Y-%m-%d")
         driver_fee = calculate_driver_fee(tags)

--- a/backend/tests/test_scan_verification.py
+++ b/backend/tests/test_scan_verification.py
@@ -1,0 +1,67 @@
+import os
+import httpx
+import asyncio
+import importlib
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+if os.path.exists("test.db"):
+    os.remove("test.db")
+
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///test.db"
+
+from app import main as app_main
+from app.db import AsyncSessionLocal, VerificationOrder
+
+importlib.reload(app_main)
+
+class DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._payload
+
+async def fake_get(self, url, auth=None, params=None):
+    # Return Shopify order without shipping address
+    return DummyResponse({"orders": [{"id": 1, "name": params["name"], "created_at": "2024-01-01T00:00:00Z", "fulfillment_status": "fulfilled", "tags": ""}]})
+
+def fake_sheet(order_name: str):
+    return None
+
+async def create_verification_row():
+    async with AsyncSessionLocal() as session:
+        vo = VerificationOrder(
+            order_date="2024-01-01",
+            order_name="#1111",
+            customer_name="Verif Name",
+            customer_phone="555-222",
+            address="Verif Address",
+        )
+        session.add(vo)
+        await session.commit()
+
+
+def test_scan_uses_verification_table(monkeypatch):
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    monkeypatch.setattr(app_main, "get_order_from_sheet", fake_sheet)
+
+    if os.path.exists("test.db"):
+        os.remove("test.db")
+
+    client = TestClient(app_main.app)
+    asyncio.run(app_main.init_db())
+    asyncio.run(create_verification_row())
+
+    resp = client.post("/scan?driver=abderrehman", json={"barcode": "#1111"})
+    assert resp.status_code == 200
+
+    resp = client.get("/orders?driver=abderrehman")
+    order = resp.json()[0]
+    assert order["customerName"] == "Verif Name"
+    assert order["customerPhone"] == "555-222"
+    assert order["address"] == "Verif Address"
+

--- a/backend/tests/test_verification.py
+++ b/backend/tests/test_verification.py
@@ -6,6 +6,9 @@ import base64
 from fastapi.testclient import TestClient
 import asyncio
 
+if os.path.exists("test.db"):
+    os.remove("test.db")
+
 os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///test.db"
 
 
@@ -39,6 +42,8 @@ def make_gspread_stub(rows, calls):
 
 
 def test_verify_endpoint(monkeypatch):
+    if os.path.exists("test.db"):
+        os.remove("test.db")
     rows = [
         ["Date","Order","Customer","Phone","Address","City","COD"],
         ["2024-01-01","#111","Alice","555","Addr","Town","100"],
@@ -74,6 +79,8 @@ def test_verify_endpoint(monkeypatch):
 
 
 def test_verify_endpoint_defaults_date(monkeypatch):
+    if os.path.exists("test.db"):
+        os.remove("test.db")
     rows = [
         ["Order", "Customer", "Phone", "Address", "City", "COD"],
         ["#222", "Bob", "555", "Addr", "Town", "200"],


### PR DESCRIPTION
## Summary
- load customer details from the verification_orders table when Shopify and sheet data are missing
- add regression tests
- reset test database between tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bcf3f47d08321b75b0394acfe5ad0