### PR TITLE
Add verification sheet sync call on scan

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -612,6 +612,11 @@ async def scan(
 ):
     async for session in get_session():
         await get_driver(session, driver)
+        scan_day = dt.datetime.now().strftime("%Y-%m-%d")
+        try:
+            await sync_verification_orders(scan_day, session)
+        except Exception:
+            logger.exception("sync_verification_orders failed")
         barcode = payload.barcode.strip()
         order_number = "#" + "".join(filter(str.isdigit, barcode))
 
@@ -713,7 +718,6 @@ async def scan(
                 address = address or vo.address or ""
 
         now_ts = dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        scan_day = dt.datetime.now().strftime("%Y-%m-%d")
         driver_fee = calculate_driver_fee(tags)
 
         order = Order(

--- a/backend/tests/test_scan_sheet.py
+++ b/backend/tests/test_scan_sheet.py
@@ -17,6 +17,9 @@ os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///test.db"
 from app import main as app_main
 importlib.reload(app_main)
 
+async def dummy_sync(date, session):
+    pass
+
 class DummyResponse:
     def __init__(self, payload):
         self._payload = payload
@@ -40,6 +43,7 @@ def fake_sheet(order_name: str):
 def test_scan_uses_sheet_when_shopify_incomplete(monkeypatch):
     monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
     monkeypatch.setattr(app_main, "get_order_from_sheet", fake_sheet)
+    monkeypatch.setattr(app_main, "sync_verification_orders", dummy_sync)
     client = TestClient(app_main.app)
     asyncio.run(app_main.init_db())
 

--- a/backend/tests/test_scan_triggers_sheet_sync.py
+++ b/backend/tests/test_scan_triggers_sheet_sync.py
@@ -1,0 +1,42 @@
+import os
+import httpx
+import asyncio
+import importlib
+import sys
+import datetime as dt
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+if os.path.exists("test.db"):
+    os.remove("test.db")
+
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///test.db"
+
+from app import main as app_main
+importlib.reload(app_main)
+
+class DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._payload
+
+async def fake_get(self, url, auth=None, params=None):
+    return DummyResponse({"orders": []})
+
+def test_scan_triggers_sheet_sync(monkeypatch):
+    calls = []
+    async def dummy_sync(date, session):
+        calls.append(date)
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    monkeypatch.setattr(app_main, "get_order_from_sheet", lambda x: None)
+    monkeypatch.setattr(app_main, "sync_verification_orders", dummy_sync)
+    client = TestClient(app_main.app)
+    asyncio.run(app_main.init_db())
+
+    resp = client.post("/scan?driver=abderrehman", json={"barcode": "#1111"})
+    assert resp.status_code == 200
+    assert calls and calls[0] == dt.datetime.now().strftime("%Y-%m-%d")

--- a/backend/tests/test_scan_verification.py
+++ b/backend/tests/test_scan_verification.py
@@ -17,6 +17,9 @@ from app.db import AsyncSessionLocal, VerificationOrder
 
 importlib.reload(app_main)
 
+async def dummy_sync(date, session):
+    pass
+
 class DummyResponse:
     def __init__(self, payload):
         self._payload = payload
@@ -48,6 +51,7 @@ async def create_verification_row():
 def test_scan_uses_verification_table(monkeypatch):
     monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
     monkeypatch.setattr(app_main, "get_order_from_sheet", fake_sheet)
+    monkeypatch.setattr(app_main, "sync_verification_orders", dummy_sync)
 
     if os.path.exists("test.db"):
         os.remove("test.db")


### PR DESCRIPTION
## Summary
- sync today's verification orders at the start of the `/scan` endpoint
- adjust tests to stub the new sync call
- add new test to ensure `/scan` triggers verification sheet sync

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bdf0011048321b7f6c0d96cdba2d6