### PR TITLE
Add aiosqlite to backend requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ echo "$GOOGLE_CREDENTIALS_B64" | base64 -d > creds.json
 
 ## Running the tests
 
-Install the requirements from `backend/requirements.txt` and run:
+Install the requirements from `backend/requirements.txt` (which now includes
+`aiosqlite`) and run:
 
 ```bash
 cd backend

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,7 @@ requests==2.32.3
 cachetools==5.3.0
 asyncpg==0.29.0
 SQLAlchemy[asyncio]==2.0.30
+aiosqlite==0.21.0
 
 redis[hiredis]==5.0.4
 fakeredis==2.21.0


### PR DESCRIPTION
## Summary
- add `aiosqlite` as a backend dependency
- mention the new dependency in setup instructions

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ccf47b45883219df56b4076b33392