### PR TITLE
Fix status list for follow agents

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -97,9 +97,6 @@ DELIVERY_STATUSES = [
 ]
 COMPLETED_STATUSES = [
     "Livré",
-    "Annulé",
-    "Refusé",
-    "Returned",
     "Deleted",
 ]
 NORMAL_DELIVERY_FEE = 20


### PR DESCRIPTION
## Summary
- keep cancelled, refused and returned orders as active orders
- update tests

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f91dcf4408321ba13b7113d349368