### PR TITLE
Add Bon de Livraison tab

### DIFF
--- a/backend/app/static/follow.html
+++ b/backend/app/static/follow.html
@@ -20,6 +20,19 @@
     .order-card{background:var(--card);border-radius:8px;padding:1rem;margin-bottom:1rem;box-shadow:0 2px 6px rgba(0,0,0,0.1);position:relative}
     .order-card.flash{animation:flash 1s}
     @keyframes flash{0%{background:yellow;}100%{background:var(--card);}}
+    .bon-card{background:#f0f0f0;border-radius:8px;margin-bottom:1rem}
+    .bon-card summary{cursor:pointer;padding:0.5rem 1rem;color:#fff}
+    .bon-table{width:100%;border-collapse:collapse}
+    .bon-table td,.bon-table th{padding:0.4rem;border-bottom:1px solid #ddd}
+    .status-chip{padding:0 0.5rem;border-radius:12px;color:#fff;font-size:0.8rem}
+    .chip-delivered{background:#4caf50}
+    .chip-cancelled{background:#f44336}
+    .chip-refused{background:#ff5722}
+    .chip-pending{background:#2196f3}
+    .accept-btn{background:#ffeb3b;border:none;padding:0.3rem 0.6rem;border-radius:6px;cursor:pointer}
+    .fade-out{animation:fadeOut 0.5s forwards}
+    @keyframes fadeOut{to{opacity:0;height:0;padding:0;margin:0}}
+    .toast{position:fixed;bottom:1rem;right:1rem;background:#333;color:#fff;padding:0.5rem 1rem;border-radius:6px;opacity:0;transition:opacity 0.3s}
     .order-header{display:flex;justify-content:space-between;font-weight:bold;color:#004aad;margin-bottom:0.5rem}
     textarea,select,input{margin-top:0.3rem;padding:0.4rem;border:1px solid #ccc;border-radius:6px;width:100%}
     .follow-log{background:#f5f5f5}
@@ -80,6 +93,7 @@
     <button data-tab="orders" class="active" onclick="showTab('orders')">Today Suivi</button>
     <button data-tab="done" onclick="showTab('done')">Done</button>
     <button data-tab="archive" onclick="showTab('archive')">Archive</button>
+    <button data-tab="bons" onclick="showTab('bons')">Bon de Livraison</button>
     <button data-tab="payouts" onclick="showTab('payouts')">Payouts</button>
   </div>
   <div class="filters" id="driverFilterContainer">
@@ -95,8 +109,10 @@
     <div id="ordersContainer"></div>
   </div>
   <div id="archive" class="tab-content"></div>
+  <div id="bons" class="tab-content"></div>
   <div id="payouts" class="tab-content"></div>
   <div id="done" class="tab-content"></div>
+  <div id="toast" class="toast"></div>
 <script>
 const API=window.location.origin.replace(/\/$/,'');
 const headers={'Content-Type':'application/json'};
@@ -118,9 +134,10 @@ function showTab(t){
   if(t==='orders') renderOrders();
   if(t==='archive') renderArchive();
   if(t==='done') renderDone();
+  if(t==='bons') renderNotes();
 }
 
-let ordersData={},archiveData={},driversCache=[];
+let ordersData={},archiveData={},notesData={},driversCache=[];
 let doneData={},driverFilterVal='',recentUpdateKey=null;
 
 async function loadAll(){
@@ -132,6 +149,7 @@ async function loadAll(){
   }
   await loadOrders(driversCache);
   await loadArchive(driversCache);
+  await loadNotes(driversCache);
   loadPayouts(driversCache);
   populateStatusFilter();
   loadDone();
@@ -148,6 +166,9 @@ async function loadAll(){
         loadOrders(driversCache);
         loadArchive(driversCache);
         loadPayouts(driversCache);
+      }
+      if(msg.type==='note_update' || msg.type==='note_approved'){
+        loadNotes(driversCache);
       }
     }catch(e){console.error('ws',e);}
   };
@@ -197,6 +218,21 @@ async function loadArchive(drivers){
   ));
   results.forEach(r=>{archiveData[r.driver]=r.data;});
   renderArchive();
+}
+
+async function loadNotes(drivers){
+  notesData={};
+  for(const d of drivers){
+    try{
+      const list=await apiGet(`/notes?driver=${d}`);
+      const items=await Promise.all(list.map(n=>apiGet(`/notes/${n.id}?driver=${d}`)));
+      notesData[d]=items;
+    }catch(e){
+      alert(`Error loading notes for ${d}: `+e);
+      notesData[d]=[];
+    }
+  }
+  renderNotes();
 }
 
 function populateStatusFilter(){
@@ -333,6 +369,58 @@ function renderDone(){
     data[d].push(v.order);
   }
   renderSection(data,document.getElementById('done'),false,false,true);
+}
+
+function renderNotes(){
+  const container=document.getElementById('bons');
+  container.innerHTML='';
+  let empty=true;
+  const colors=['#ff5722','#4caf50','#03a9f4','#ff9800','#e91e63','#009688'];
+  for(const [d,notes] of Object.entries(notesData)){
+    if(driverFilterVal && d!==driverFilterVal) continue;
+    const idx=driversCache.indexOf(d);
+    const color=colors[idx%colors.length];
+    notes.forEach(n=>{
+      empty=false;
+      const det=document.createElement('details');
+      det.className='bon-card';
+      const sum=document.createElement('summary');
+      sum.style.background=color;
+      sum.textContent=`BON #${n.id} – ${d} – Created ${n.createdAt}`;
+      det.appendChild(sum);
+      const table=document.createElement('table');
+      table.className='bon-table';
+      const tbody=document.createElement('tbody');
+      n.items.forEach(it=>{
+        const tr=document.createElement('tr');
+        const status=it.status;
+        const chip=document.createElement('span');
+        chip.className='status-chip '+(
+          status==='Livré'? 'chip-delivered':
+          status==='Annulé'? 'chip-cancelled':
+          status==='Refusé'? 'chip-refused':
+          ['Cancelled','Returned'].includes(status)? 'chip-cancelled':'chip-pending'
+        );
+        chip.textContent=status;
+        tr.innerHTML=`<td>${it.orderName}</td><td></td><td>${it.cashAmount} DH</td><td></td>`;
+        tr.children[1].appendChild(chip);
+        if(['Cancelled','Refusé','Returned','Annulé'].includes(status)){
+          const btn=document.createElement('button');
+          btn.className='accept-btn';
+          btn.innerHTML='♻️ Accept Return';
+          btn.onclick=()=>acceptReturn(d,it.orderName,status,tr);
+          tr.children[3].appendChild(btn);
+        }
+        tbody.appendChild(tr);
+      });
+      table.appendChild(tbody);
+      det.appendChild(table);
+      container.appendChild(det);
+    });
+  }
+  if(empty){
+    container.innerHTML='<div class="no-orders">No bons for this driver today</div>';
+  }
 }
 
 async function loadPayouts(drivers){
@@ -556,6 +644,25 @@ function sendAgentNote(driver,order){
 
 function flashCard(id){
   const el=document.getElementById('card-'+id);if(!el)return;el.classList.add('flash');setTimeout(()=>el.classList.remove('flash'),1000);
+}
+
+function acceptReturn(driver,order,status,row){
+  row.classList.add('fade-out');
+  apiPut(`/order/status?driver=${driver}`,{order_name:order,new_status:status})
+    .then(()=>{
+      setTimeout(()=>row.remove(),500);
+      showToast('Return accepted \u2713');
+      loadArchive(driversCache);
+    })
+    .catch(e=>alert('Error accepting return: '+e));
+}
+
+function showToast(msg){
+  const t=document.getElementById('toast');
+  if(!t) return;
+  t.textContent=msg;
+  t.style.opacity='1';
+  setTimeout(()=>{t.style.opacity='0';},2000);
 }
 
 function toggleDark(){document.body.classList.toggle('dark');}


### PR DESCRIPTION
## Summary
- add Bon de Livraison tab on follow dashboard
- fetch notes for drivers and render collapsible bon cards
- allow accepting returned orders with a toast
- include small visual updates for bons

## Testing
- `python -m pytest -q` *(fails: OperationalError - no such table: drivers)*

------
https://chatgpt.com/codex/tasks/task_e_68811f6b6b608321966e9d7d65bb614b