### PR TITLE
Mark orders paid when payout is marked paid

### DIFF
--- a/backend/app/static/admin_dashboard.html
+++ b/backend/app/static/admin_dashboard.html
@@ -153,6 +153,7 @@
         <option value="">Any status</option>
         <option value="Dispatched">Dispatched</option>
         <option value="Livré">Livré</option>
+        <option value="Paid">Paid</option>
         <option value="Returned">Returned</option>
         <option value="Annulé">Annulé</option>
         <option value="Refusé">Refusé</option>

--- a/backend/app/static/follow.html
+++ b/backend/app/static/follow.html
@@ -50,6 +50,7 @@
     .tag-ch{background:#ffab91;color:#333}
     .status-chip{padding:0.1rem 0.4rem;border-radius:4px;color:#fff;font-size:0.8rem}
     .status-delivered{background:#4caf50}
+    .status-paid{background:#1976d2}
     .status-cancelled{background:#f44336}
     .status-refusee{background:#ff9800}
     .status-pending{background:#2196f3}
@@ -127,8 +128,8 @@ const handleResp=async r=>{if(!r.ok){const t=await r.text();throw t||r.status;}r
 const apiGet=p=>fetch(API+p).then(handleResp);
 const apiPut=(p,b={})=>fetch(API+p,{method:'PUT',headers,body:JSON.stringify(b)}).then(handleResp);
 
-const deliveryStatuses=['Dispatched','Livré','En cours','Pas de réponse 1','Pas de réponse 2','Pas de réponse 3','Annulé','Refusé','Rescheduled','Returned'];
-const statusColors={'Livré':'#4caf50','Annulé':'#f44336','Refusé':'#f44336','Returned':'#f44336','En cours':'#ffeb3b'};
+const deliveryStatuses=['Dispatched','Livré','Paid','En cours','Pas de réponse 1','Pas de réponse 2','Pas de réponse 3','Annulé','Refusé','Rescheduled','Returned'];
+const statusColors={'Livré':'#4caf50','Paid':'#1976d2','Annulé':'#f44336','Refusé':'#f44336','Returned':'#f44336','En cours':'#ffeb3b'};
 
 let prevState={};
 
@@ -286,7 +287,7 @@ function renderNotes(){
       html+=`<details class="order-card"><summary style="background:${color};color:#fff;padding:0.4rem;border-radius:4px">DN #${n.id} – ${d} – Created ${n.createdAt}</summary><div style="padding:0.5rem">`;
       html+=`<table style="width:100%;border-collapse:collapse;font-size:0.9rem"><thead><tr><th>Order</th><th>Status</th><th>COD</th><th>Action</th></tr></thead><tbody>`;
       n.items.forEach(it=>{
-        const cls=it.status==='Livré'?'status-delivered':(it.status==='Returned'?'status-cancelled':(it.status==='Annulé'?'status-cancelled':(it.status==='Refusé'?'status-refusee':'status-pending')));
+        const cls=it.status==='Paid'?'status-paid':(it.status==='Livré'?'status-delivered':(it.status==='Returned'?'status-cancelled':(it.status==='Annulé'?'status-cancelled':(it.status==='Refusé'?'status-refusee':'status-pending'))));
         const btn=['Cancelled','Annulé','Refusé','Returned'].includes(it.status)?`<button class="return-btn" onclick="acceptReturn('${d}','${it.orderName}',this)">♻️ Accept Return</button>`:'';
         html+=`<tr><td>${it.orderName}</td><td><span class="status-chip ${cls}">${it.status}</span></td><td>${it.cashAmount}</td><td>${btn}</td></tr>`;
       });

--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -369,7 +369,7 @@
      2.  Globals copied from old code
      ────────────────────────────────────────────────────────────*/
   let scanner, orders = [], archive = [], payouts = [], notes = [];
-  const deliveryStatuses = ['Dispatched','Livré','En cours','Pas de réponse 1','Pas de réponse 2','Pas de réponse 3','Annulé','Refusé','Rescheduled','Returned'];
+  const deliveryStatuses = ['Dispatched','Livré','Paid','En cours','Pas de réponse 1','Pas de réponse 2','Pas de réponse 3','Annulé','Refusé','Rescheduled','Returned'];
   const formatMoney = n => (parseFloat(n) || 0).toFixed(2).replace('.', ',');
 
   function animateValue(id,start,end,duration){
@@ -391,7 +391,7 @@
 
   function buildOrdersChart() {
     if(!orders.length) return;
-    const delivered = orders.filter(o => o.deliveryStatus === 'Livré').length;
+    const delivered = orders.filter(o => ['Livré','Paid'].includes(o.deliveryStatus)).length;
     const failed = orders.filter(o => ['Annulé','Refusé','Returned'].includes(o.deliveryStatus)).length;
     const dispatched = orders.filter(o => o.deliveryStatus === 'Dispatched').length;
     const inprog = orders.length - delivered - failed - dispatched;
@@ -620,7 +620,7 @@
   }
 
   function displayOrders(ol){
-    orders = (ol || []).filter(o=>!['Livré','Annulé','Refusé','Returned','Canceled','Cancelled'].includes(o.deliveryStatus));
+    orders = (ol || []).filter(o=>!['Livré','Paid','Annulé','Refusé','Returned','Canceled','Cancelled'].includes(o.deliveryStatus));
     const c = document.getElementById('ordersContainer');
     if(!orders.length){ c.innerHTML='<div class="no-orders">📭 No active orders found.</div>'; return; }
 
@@ -651,7 +651,7 @@
       const tc = getPrimaryTag(o.tags);
       const isExchange = tc==='ch' || (o.tags||'').toLowerCase().includes('ch');
       const fee = isExchange ? 10 : 20;
-      const delivered = o.deliveryStatus === 'Livré';
+      const delivered = ['Livré','Paid'].includes(o.deliveryStatus);
       const waMsg = encodeURIComponent(
         `Salam/Bonjour ${o.customerName||''}, votre livreur ${driver_id} vous contacte. ` +
         `J'ai votre commande numéro ${o.orderName} d'un total de ${o.cashAmount||0} DH. ` +


### PR DESCRIPTION
## Summary
- track a new "Paid" delivery status
- mark all payout orders as Paid when payout is completed
- count Paid orders as delivered in stats
- surface Paid status in follow dashboard and admin dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688236146ac88321b7a47d15118d8193