### PR TITLE
Sync paid status badges

### DIFF
--- a/backend/app/static/follow.html
+++ b/backend/app/static/follow.html
@@ -54,6 +54,7 @@
     .status-cancelled{background:#f44336}
     .status-refusee{background:#ff9800}
     .status-pending{background:#2196f3}
+    .paid-badge{background:#4caf50;color:#fff;padding:0.1rem 0.4rem;border-radius:4px;font-size:0.8rem;margin-left:0.3rem}
     .filters{position:sticky;top:3.5rem;background:var(--bg);padding-bottom:0.5rem;z-index:100}
     #orders .filters{top:6.5rem}
     #driverFilter{display:flex;gap:0.5rem;flex-wrap:wrap;margin-bottom:0.5rem;width:100%}
@@ -289,7 +290,8 @@ function renderNotes(){
       n.items.forEach(it=>{
         const cls=it.status==='Paid'?'status-paid':(it.status==='Livré'?'status-delivered':(it.status==='Returned'?'status-cancelled':(it.status==='Annulé'?'status-cancelled':(it.status==='Refusé'?'status-refusee':'status-pending'))));
         const btn=['Cancelled','Annulé','Refusé','Returned'].includes(it.status)?`<button class="return-btn" onclick="acceptReturn('${d}','${it.orderName}',this)">♻️ Accept Return</button>`:'';
-        html+=`<tr><td>${it.orderName}</td><td><span class="status-chip ${cls}">${it.status}</span></td><td>${it.cashAmount}</td><td>${btn}</td></tr>`;
+        const label=it.status==='Paid'?'Paid DH ✓':it.status;
+        html+=`<tr><td>${it.orderName}</td><td><span class="status-chip ${cls}">${label}</span></td><td>${it.cashAmount}</td><td>${btn}</td></tr>`;
       });
       html+=`</tbody></table></div></details>`;
     });
@@ -341,7 +343,7 @@ function renderSection(dataObj,container,includeInputs,showDone,showUndone){
       const border=statusColors[o.deliveryStatus]||'#004aad';
       const waUrl=o.customerPhone?`https://wa.me/${o.customerPhone}`:'';
       html+=`<div id="card-${key}" class="order-card ${o.urgent?'followup':''}" style="border-left-color:${border}">
-        <div class="order-header"><span style="font-size:1.2rem;font-weight:bold">${o.orderName}</span>${o.urgent?'<span class="urgent-icon">🔔</span>':''}<span style="font-size:0.9rem">${o.deliveryStatus}</span></div>
+        <div class="order-header"><span style="font-size:1.2rem;font-weight:bold">${o.orderName}</span>${o.urgent?'<span class="urgent-icon">🔔</span>':''}${o.deliveryStatus==='Paid'?'<span class="paid-badge">Paid DH ✓</span>':`<span style="font-size:0.9rem">${o.deliveryStatus}</span>`}</div>
         <div>${o.customerName||''}</div>
         <div>${o.customerPhone?`📞 ${o.customerPhone} <a href="tel:${o.customerPhone}" onclick="return recordCall('${key}')">📞</a> ${waUrl?`<a href="${waUrl}" target="_blank" onclick="return recordWhatsapp('${key}')">💬</a>`:''}`:''}</div>
         <div>${o.address||''}</div>
@@ -413,7 +415,7 @@ function renderArchive(){
         const border=statusColors[o.deliveryStatus]||'#004aad';
         const waUrl=o.customerPhone?`https://wa.me/${o.customerPhone}`:'';
         html+=`<div id="card-${key}" class="order-card" style="border-left-color:${border}">`+
-          `<div class="order-header"><span style="font-size:1.2rem;font-weight:bold">${o.orderName}</span><span style="font-size:0.9rem">${o.deliveryStatus}</span></div>`+
+          `<div class="order-header"><span style="font-size:1.2rem;font-weight:bold">${o.orderName}</span>${o.deliveryStatus==='Paid'?'<span class="paid-badge">Paid DH ✓</span>':'<span style="font-size:0.9rem">'+o.deliveryStatus+'</span>'}</div>`+
           `<div>${o.customerName||''}</div>`+
           `<div>${o.customerPhone?`📞 ${o.customerPhone}`:''}</div>`+
           `<div>${o.address||''}</div>`+

--- a/backend/tests/test_payout_sync.py
+++ b/backend/tests/test_payout_sync.py
@@ -1,0 +1,46 @@
+import os, asyncio, sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+db_path = 'payout.db'
+if os.path.exists(db_path):
+    os.remove(db_path)
+os.environ['DATABASE_URL'] = f'sqlite+aiosqlite:///{db_path}'
+
+from sqlalchemy import select
+
+def setup_app():
+    from app import main as app_main
+    from app import db as app_db
+    client = TestClient(app_main.app)
+    asyncio.run(app_main.init_db())
+    return app_main, app_db, client
+
+async def setup_records(app_main, app_db):
+    async with app_db.AsyncSessionLocal() as session:
+        if not await session.get(app_db.Driver, 'abder'):
+            session.add(app_db.Driver(id='abder'))
+        order = app_db.Order(driver_id='abder', order_name='#1', delivery_status='Livré', cash_amount=100, payout_id='PO-1')
+        payout = app_db.Payout(driver_id='abder', payout_id='PO-1', orders='#1', total_cash=100, total_fees=20, total_payout=80, status='pending')
+        session.add_all([order, payout])
+        await session.commit()
+
+def get_order_status(app_main, app_db):
+    async def inner():
+        async with app_db.AsyncSessionLocal() as session:
+            o = await session.scalar(select(app_db.Order).where(app_db.Order.order_name=='#1'))
+            return o.delivery_status
+    return asyncio.run(inner())
+
+def test_mark_paid_and_unpaid():
+    app_main, app_db, client = setup_app()
+    asyncio.run(setup_records(app_main, app_db))
+
+    resp = client.post('/payout/mark-paid/PO-1?driver=abder')
+    assert resp.status_code == 200
+    assert get_order_status(app_main, app_db) == 'Paid'
+
+    resp = client.post('/payout/mark-unpaid/PO-1?driver=abder')
+    assert resp.status_code == 200
+    assert get_order_status(app_main, app_db) == 'Livré'


### PR DESCRIPTION
## Summary
- add `paid-badge` CSS and show it when orders are paid
- broadcast WebSocket updates when payout status changes
- support reversing a payout to unpaid
- test payout status syncing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882498044b08321b7b06ebaf806d486