### PR TITLE
Add tag summary endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1547,6 +1547,26 @@ async def _compute_stats(
     }
 
 
+async def get_tag_summary(session: AsyncSession) -> dict[str, dict[str, int]]:
+    """Return count of primary tags per store."""
+    result = await session.execute(select(Order.tags, Order.store))
+    summary: dict[str, dict[str, int]] = {}
+    for tags, store in result.all():
+        tag = get_primary_display_tag(tags)
+        if not tag:
+            continue
+        store_name = store or ""
+        summary.setdefault(tag, {})
+        summary[tag][store_name] = summary[tag].get(store_name, 0) + 1
+    return summary
+
+
+@app.get("/tag-summary", tags=["stats"])
+async def tag_summary():
+    async for session in get_session():
+        return await get_tag_summary(session)
+
+
 @app.get("/stats", tags=["stats"])
 async def get_stats(
     driver: str = Query(...),

--- a/backend/tests/test_tag_summary.py
+++ b/backend/tests/test_tag_summary.py
@@ -1,0 +1,46 @@
+import os
+import asyncio
+import importlib
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+DB_FILE = 'tag_summary.db'
+if os.path.exists(DB_FILE):
+    os.remove(DB_FILE)
+
+os.environ['DATABASE_URL'] = f'sqlite+aiosqlite:///{DB_FILE}'
+
+from app import main as app_main
+from app import db as app_db
+
+importlib.reload(app_main)
+
+async def create_orders():
+    async with app_db.AsyncSessionLocal() as session:
+        session.add(app_db.Order(driver_id='abderrehman', order_name='#1', store='irrakids', tags='big', delivery_status='Dispatched'))
+        session.add(app_db.Order(driver_id='abderrehman', order_name='#2', store='irrakids', tags='fast', delivery_status='Dispatched'))
+        session.add(app_db.Order(driver_id='abderrehman', order_name='#3', store='irranova', tags='fast', delivery_status='Dispatched'))
+        session.add(app_db.Order(driver_id='abderrehman', order_name='#4', store='irranova', tags='big fast', delivery_status='Dispatched'))
+        session.add(app_db.Order(driver_id='abderrehman', order_name='#5', store='irrakids', tags='oscario', delivery_status='Dispatched'))
+        session.add(app_db.Order(driver_id='abderrehman', order_name='#6', store='irranova', tags='', delivery_status='Dispatched'))
+        await session.commit()
+
+def setup_app():
+    client = TestClient(app_main.app)
+    asyncio.run(app_main.init_db())
+    asyncio.run(create_orders())
+    return client
+
+def test_tag_summary():
+    client = setup_app()
+    resp = client.get('/tag-summary')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['big']['irrakids'] == 1
+    assert data['big']['irranova'] == 1
+    assert data['fast']['irrakids'] == 1
+    assert data['fast']['irranova'] == 1
+    assert data['oscario']['irrakids'] == 1
+    assert 'irranova' not in data['oscario']


### PR DESCRIPTION
## Summary
- compute tag summary counts per store
- expose `/tag-summary` endpoint
- test tag summary aggregation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825eadb45c8321ad190299e88ed6bd