### PR TITLE
Fix SQLAlchemy null checks; document verification sheet env

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The backend is configured entirely through environment variables:
   `admin123`).
 - `REDIS_URL` – optional Redis instance used for caching.
 - `SHEET_ID` – ID of the Google Sheet providing fallback order data.
+- `VERIFICATION_SHEET_ID` – optional ID of the verification Google Sheet.
 - `GOOGLE_CREDENTIALS_B64` – **preferred**; base64 encoded service account JSON.
 - `GOOGLE_APPLICATION_CREDENTIALS` – optional path to the credentials file.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -980,7 +980,7 @@ async def list_active_orders(driver: str = Query(...)):
                 Order.delivery_status.notin_(COMPLETED_STATUSES),
                 or_(
                     DeliveryNote.status == "approved",
-                    DeliveryNote.id == None,
+                    DeliveryNote.id.is_(None),
                 ),
             )
         )
@@ -1052,7 +1052,7 @@ async def list_archived_orders(driver: str = Query(...)):
                 Order.delivery_status.in_(ARCHIVE_STATUSES),
                 or_(
                     DeliveryNote.status == "approved",
-                    DeliveryNote.id == None,
+                    DeliveryNote.id.is_(None),
                 ),
             )
             .order_by(Order.timestamp.desc())
@@ -1104,7 +1104,7 @@ async def list_all_orders(driver: str = Query(...)):
                 Order.delivery_status != "Deleted",
                 or_(
                     DeliveryNote.status == "approved",
-                    DeliveryNote.id == None,
+                    DeliveryNote.id.is_(None),
                 ),
             )
         )
@@ -1155,7 +1155,7 @@ async def list_followup_orders(driver: str = Query(...)):
                 Order.delivery_status.notin_(COMPLETED_STATUSES),
                 or_(
                     DeliveryNote.status == "approved",
-                    DeliveryNote.id == None,
+                    DeliveryNote.id.is_(None),
                 ),
             )
         )


### PR DESCRIPTION
## Summary
- mention `VERIFICATION_SHEET_ID` in README
- use `is_(None)` instead of `== None` in order queries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688362992a6483218c42070737261894