### PR TITLE
Add landing page and updated login flows

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -338,23 +338,37 @@ async def sync_verification_orders(date_str: str, session: AsyncSession) -> None
 
 
 @app.get("/", response_class=HTMLResponse)
-async def show_login():
+async def show_landing():
+    """Landing page with links to the individual login pages."""
+    return FileResponse(os.path.join(STATIC_DIR, "landing.html"))
+
+
+@app.get("/driver-login", response_class=HTMLResponse)
+async def show_driver_login():
     return FileResponse(os.path.join(STATIC_DIR, "login.html"))
 
 
-@app.get("/admin", response_class=HTMLResponse)
+@app.get("/admin-login", response_class=HTMLResponse)
 async def show_admin_login():
     return FileResponse(os.path.join(STATIC_DIR, "admin_login.html"))
 
+@app.get("/admin", response_class=HTMLResponse)
+async def show_admin_login_alias():
+    return await show_admin_login()
 
-@app.get("/follow", response_class=HTMLResponse)
+
+@app.get("/follow-login", response_class=HTMLResponse)
 async def show_follow_login():
     """Serve login page for follow agents."""
     return FileResponse(os.path.join(STATIC_DIR, "follow_login.html"))
 
+@app.get("/follow", response_class=HTMLResponse)
+async def show_follow_login_alias():
+    return await show_follow_login()
+
 
 @app.post("/login", response_class=HTMLResponse)
-async def login(driver_id: str = Form(...)):
+async def login(driver_id: str = Form(...), password: str | None = Form(None)):
     async for session in get_session():
         drivers = await load_drivers(session)
         if driver_id in drivers:
@@ -373,7 +387,7 @@ async def admin_login(password: str = Form(...)):
 
 
 @app.post("/follow/login")
-async def follow_login(password: str = Form(...)):
+async def follow_login(username: str = Form(...), password: str = Form(...)):
     """Authenticate follow agents using the admin password for now."""
     if password == ADMIN_PASSWORD:
         return {"success": True}

--- a/backend/app/static/admin_login.html
+++ b/backend/app/static/admin_login.html
@@ -16,7 +16,8 @@
 <body>
   <div class="login-box">
     <h2>🔒 Admin Login</h2>
-    <input id="adminPassword" type="password" placeholder="Enter admin password" />
+    <!-- Biometric login would be triggered here if supported -->
+    <input id="adminPassword" type="password" placeholder="Password or PIN" />
     <button onclick="login()">Login</button>
   </div>
 

--- a/backend/app/static/follow_login.html
+++ b/backend/app/static/follow_login.html
@@ -8,7 +8,7 @@
     body{font-family:sans-serif;display:flex;justify-content:center;align-items:center;height:100vh;background:#f0f0f0;margin:0;}
     .login-box{background:white;padding:2rem;border-radius:12px;box-shadow:0 2px 20px rgba(0,0,0,0.1);text-align:center;}
     h2{margin-bottom:1rem;color:#004aad;}
-    input[type="password"]{padding:0.8rem;width:100%;margin-bottom:1rem;font-size:1rem;border:2px solid #ccc;border-radius:8px;}
+    input[type="text"], input[type="password"]{padding:0.8rem;width:100%;margin-bottom:1rem;font-size:1rem;border:2px solid #ccc;border-radius:8px;}
     button{padding:0.8rem 1.5rem;background:#004aad;color:white;border:none;border-radius:8px;font-size:1rem;cursor:pointer;}
     button:hover{background:#0066cc;}
   </style>
@@ -16,14 +16,16 @@
 <body>
   <div class="login-box">
     <h2>🔒 Follow Agent Login</h2>
-    <input id="followPassword" type="password" placeholder="Enter password" />
+    <input id="followUser" type="text" placeholder="Username" />
+    <input id="followPassword" type="password" placeholder="Password" />
     <button onclick="login()">Login</button>
   </div>
 <script>
 function login(){
+  const user=document.getElementById('followUser').value.trim();
   const pw=document.getElementById('followPassword').value.trim();
-  fetch('/follow/login',{method:'POST',body:new URLSearchParams({password:pw})})
-    .then(r=>r.ok?location.href='/static/follow.html':alert('Invalid password'));
+  fetch('/follow/login',{method:'POST',body:new URLSearchParams({username:user,password:pw})})
+    .then(r=>r.ok?location.href='/static/follow.html':alert('Invalid login')); 
 }
 </script>
 </body>

--- a/backend/app/static/landing.html
+++ b/backend/app/static/landing.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Amanex Delivery Platform</title>
+  <style>
+    body {font-family:sans-serif;margin:0;display:flex;justify-content:center;align-items:center;height:100vh;background:#f5f7fa;}
+    .container {text-align:center;}
+    h1 {font-size:2rem;color:#004aad;margin-bottom:2rem;}
+    .grid {display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));width:100%;max-width:600px;}
+    .card {padding:1.5rem;border-radius:12px;background:white;box-shadow:0 2px 8px rgba(0,0,0,0.1);cursor:pointer;font-size:1.1rem;font-weight:600;color:#004aad;transition:background 0.2s;}
+    .card:hover {background:#e8f0fe;}
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>🚚 Amanex Delivery Platform</h1>
+    <div class="grid">
+      <div class="card" onclick="location.href='/admin-login'">Admin Dashboard</div>
+      <div class="card" onclick="location.href='/driver-login'">Driver Login</div>
+      <div class="card" onclick="location.href='/follow-login'">Follow-Up Login</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/backend/app/static/login.html
+++ b/backend/app/static/login.html
@@ -8,7 +8,7 @@
     body {font-family:sans-serif;display:flex;justify-content:center;align-items:center;height:100vh;background:#f0f0f0;margin:0;}
     .login-box {background:white;padding:2rem;border-radius:12px;box-shadow:0 2px 20px rgba(0,0,0,0.1);text-align:center;}
     h2 {margin-bottom:1rem;color:#004aad;}
-    input[type="text"] {padding:0.8rem;width:100%;margin-bottom:1rem;font-size:1rem;border:2px solid #ccc;border-radius:8px;}
+    input[type="text"], input[type="password"] {padding:0.8rem;width:100%;margin-bottom:1rem;font-size:1rem;border:2px solid #ccc;border-radius:8px;}
     button {padding:0.8rem 1.5rem;background:#004aad;color:white;border:none;border-radius:8px;font-size:1rem;cursor:pointer;}
     button:hover {background:#0066cc;}
   </style>
@@ -16,7 +16,8 @@
 <body>
   <div class="login-box">
     <h2>🔒 Driver Login</h2>
-    <input id="driverCode" type="text" placeholder="Enter your driver code" />
+    <input id="driverUser" type="text" placeholder="Username" />
+    <input id="driverPass" type="password" placeholder="Password" />
     <button onclick="login()">Login</button>
   </div>
 
@@ -35,12 +36,13 @@
       });
 
       function login() {
-        const code = document.getElementById('driverCode').value.trim();
-        if (driverIds.has(code)) {
-          localStorage.setItem('driver_id', code);
-          location.href = `/static/index.html?driver=${code}`;
+        const user = document.getElementById('driverUser').value.trim();
+        const pass = document.getElementById('driverPass').value.trim();
+        if (driverIds.has(user)) {
+          fetch('/login', {method:'POST', body:new URLSearchParams({driver_id:user, password:pass})})
+            .then(r => r.ok ? location.href=`/static/index.html?driver=${user}` : alert('Login failed'));
         } else {
-          alert('Invalid code. Please try again.');
+          alert('Invalid user. Please try again.');
         }
       }
     </script>


### PR DESCRIPTION
## Summary
- add `landing.html` with cards linking to Admin, Driver and Follow-Up logins
- update FastAPI routes to serve new landing page and login URLs
- extend login forms to accept username and password
- minor tweak to admin login copy

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688374475d30832195e4ac64f1855b7e