### PR TITLE
Remove ffmpeg from Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,8 +5,6 @@ FROM python:3.12-slim
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         build-essential \
-        # (ffmpeg only if you really need it; drop it to save ~45 MB)
-        ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # 2) Python deps ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- trim ffmpeg package from backend Dockerfile to reduce image size

## Testing
- `pytest -q`
- ❌ `docker build -t delivery-app-backend-test -f backend/Dockerfile backend` *(fails: docker daemon could not start)*

------
https://chatgpt.com/codex/tasks/task_e_688390e207e08321be75b492bad8d9a4