### PR TITLE
Add follow agent management

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -10,6 +10,8 @@ from sqlalchemy import (
 from sqlalchemy.orm import declarative_base, relationship
 from datetime import datetime
 
+from sqlalchemy import Table
+
 Base = declarative_base()
 
 class Driver(Base):
@@ -106,3 +108,28 @@ class VerificationOrder(Base):
     scan_time = Column(DateTime)
 
     driver = relationship("Driver")
+
+
+# ---------------------------------------------------------------------------
+# Follow Agents and assignments
+# ---------------------------------------------------------------------------
+
+# Association table linking follow agents to drivers they manage
+agent_driver_table = Table(
+    "agent_drivers",
+    Base.metadata,
+    Column("agent_id", Integer, ForeignKey("agents.id"), primary_key=True),
+    Column("driver_id", String, ForeignKey("drivers.id"), primary_key=True),
+)
+
+
+class Agent(Base):
+    """Follow agent able to access specific drivers."""
+
+    __tablename__ = "agents"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    username = Column(String, unique=True, nullable=False)
+    password = Column(String, nullable=False)
+
+    drivers = relationship("Driver", secondary=agent_driver_table, backref="agents")

--- a/backend/app/static/admin_dashboard.html
+++ b/backend/app/static/admin_dashboard.html
@@ -28,6 +28,7 @@
     <div class="tab" data-tab="verify" onclick="activateTab('verify');loadVerifyTab()">Order Verification</div>
     <div class="tab" data-tab="parcels" onclick="activateTab('parcels');loadParcelsTab()">Parcels DB</div>
     <div class="tab" data-tab="payouts" onclick="activateTab('payouts');loadPayoutsTab()">Payouts DB</div>
+    <div class="tab" data-tab="agents" onclick="activateTab('agents');loadAgentsTab()">Agents</div>
     <div class="tab" data-tab="placeholder" onclick="activateTab('placeholder')">Other</div>
   </div>
 
@@ -201,6 +202,18 @@
         <tbody id="payoutsBody"></tbody>
       </table>
     </div>
+  </div>
+
+  <!-- Agents management tab -->
+  <div id="agents" class="tab-content">
+    <h2 class="text-lg font-semibold mb-3">Agents</h2>
+    <div class="mb-3">
+      <input id="agentName" placeholder="Username" class="border p-1 rounded" />
+      <input id="agentPass" type="password" placeholder="Password" class="border p-1 rounded" />
+      <input id="agentDrivers" placeholder="Drivers (comma separated)" class="border p-1 rounded" />
+      <button onclick="addAgent()" class="px-3 py-1 bg-green-600 text-white rounded">Add</button>
+    </div>
+    <div id="agentsList"></div>
   </div>
 
   <div id="placeholder" class="tab-content">
@@ -409,6 +422,24 @@ async function loadPayouts(){
     body.appendChild(tr);
   });
 }
+
+// ----------------------- AGENTS -------------------------------
+async function loadAgentsTab(){
+  const list=document.getElementById('agentsList');
+  const data=await fetch('/admin/agents').then(r=>r.json()).catch(()=>[]);
+  list.innerHTML=data.map(a=>`<div class='border p-2 my-1'>${a.username} – drivers: ${a.drivers.join(', ')}</div>`).join('');
+}
+async function addAgent(){
+  const name=document.getElementById('agentName').value.trim();
+  const pw=document.getElementById('agentPass').value.trim();
+  const drivers=document.getElementById('agentDrivers').value.trim();
+  if(!name||!pw)return;
+  await fetch('/admin/agents',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({username:name,password:pw,drivers:drivers?drivers.split(',').map(s=>s.trim()):[]})});
+  document.getElementById('agentName').value='';
+  document.getElementById('agentPass').value='';
+  document.getElementById('agentDrivers').value='';
+  loadAgentsTab();
+}
 document.getElementById('payoutsBody').addEventListener('dblclick',async e=>{
   const td=e.target.closest('td[data-field]');
   if(!td)return;const field=td.dataset.field;const id=td.parentNode.dataset.id;const val=prompt(`Edit ${field}`,td.textContent);if(val===null)return;td.textContent=val;const driver=document.getElementById('payoutsDriver').value;let payload={};
@@ -478,6 +509,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   const ws=new WebSocket(`${wsProtocol}://${location.host}/ws`);
   ws.onmessage=evt=>{try{const m=JSON.parse(evt.data);if((m.type==='note_update'||m.type==='note_approved')&&m.driver===currentDriver){loadAdminNotes();}}catch(e){}};
   loadVerifyTab();
+  loadAgentsTab();
 });
 </script>
 </body>

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -1,0 +1,36 @@
+import os, asyncio, sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+db_file = 'agents_test.db'
+if os.path.exists(db_file):
+    os.remove(db_file)
+os.environ['DATABASE_URL'] = f'sqlite+aiosqlite:///{db_file}'
+
+def setup_app():
+    from app import main as app_main
+    from app import db as app_db
+    from app import models as app_models
+    client = TestClient(app_main.app)
+    asyncio.run(app_main.init_db())
+    return app_main, app_db, app_models, client
+
+async def create_agent(app_db, models):
+    async with app_db.AsyncSessionLocal() as session:
+        driver = models.Driver(id='d1')
+        agent = models.Agent(username='alice', password='secret', drivers=[driver])
+        session.add_all([driver, agent])
+        await session.commit()
+
+
+def test_follow_login_and_drivers():
+    app_main, app_db, app_models, client = setup_app()
+    asyncio.run(create_agent(app_db, app_models))
+
+    resp = client.post('/follow/login', data={'username':'alice','password':'secret'})
+    assert resp.status_code == 200
+    cookies = resp.cookies
+    resp = client.get('/drivers', cookies={'agent': cookies.get('agent')})
+    assert resp.status_code == 200
+    assert resp.json() == ['d1']


### PR DESCRIPTION
## Summary
- support follow agent login based on an Agent table
- filter `/drivers` by agent assignments and add basic admin agent CRUD API
- show an Agents tab in the dashboard with a simple interface
- test follow agent login and driver filtering

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a78a53448321a93454312c371f45