### PR TITLE
Ensure admin login clears agent cookie

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -429,10 +429,12 @@ async def follow_login(response: Response, username: str = Form(...), password: 
 
 
 @app.get("/drivers")
-async def list_drivers(request: Request, agent: str | None = None):
+async def list_drivers(request: Request, agent: str | None = None, all: bool = False):
     """List drivers; if agent cookie or query provided, filter assignments."""
     async for session in get_session():
         drivers = await load_drivers(session)
+        if all:
+            return list(drivers.keys())
         if not agent:
             agent = request.cookies.get("agent")
         if agent:

--- a/backend/app/static/admin_login.html
+++ b/backend/app/static/admin_login.html
@@ -25,7 +25,14 @@
     function login() {
       const pw = document.getElementById('adminPassword').value.trim();
       fetch('/admin/login', {method:'POST', body:new URLSearchParams({password: pw})})
-        .then(r => r.ok ? location.href='/static/admin_dashboard.html' : alert('Invalid password'));
+        .then(r => {
+          if (r.ok) {
+            document.cookie = 'agent=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+            location.href='/static/admin_dashboard.html';
+          } else {
+            alert('Invalid password');
+          }
+        });
     }
   </script>
 </body>

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -1,14 +1,15 @@
 import os, asyncio, sys
 from fastapi.testclient import TestClient
+from sqlalchemy import select
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 db_file = 'agents_test.db'
-if os.path.exists(db_file):
-    os.remove(db_file)
 os.environ['DATABASE_URL'] = f'sqlite+aiosqlite:///{db_file}'
 
 def setup_app():
+    if os.path.exists(db_file):
+        os.remove(db_file)
     from app import main as app_main
     from app import db as app_db
     from app import models as app_models
@@ -16,11 +17,20 @@ def setup_app():
     asyncio.run(app_main.init_db())
     return app_main, app_db, app_models, client
 
-async def create_agent(app_db, models):
+async def create_agent(app_db, models, username='alice'):
     async with app_db.AsyncSessionLocal() as session:
-        driver = models.Driver(id='d1')
-        agent = models.Agent(username='alice', password='secret', drivers=[driver])
-        session.add_all([driver, agent])
+        driver1 = await session.get(models.Driver, 'd1')
+        if not driver1:
+            driver1 = models.Driver(id='d1')
+            session.add(driver1)
+        driver2 = await session.get(models.Driver, 'd2')
+        if not driver2:
+            driver2 = models.Driver(id='d2')
+            session.add(driver2)
+        agent = await session.scalar(select(models.Agent).where(models.Agent.username == username))
+        if not agent:
+            agent = models.Agent(username=username, password='secret', drivers=[driver1])
+            session.add(agent)
         await session.commit()
 
 
@@ -34,3 +44,30 @@ def test_follow_login_and_drivers():
     resp = client.get('/drivers', cookies={'agent': cookies.get('agent')})
     assert resp.status_code == 200
     assert resp.json() == ['d1']
+
+
+def test_drivers_all_query():
+    app_main, app_db, app_models, client = setup_app()
+    asyncio.run(create_agent(app_db, app_models, username='bob'))
+
+    resp = client.post('/follow/login', data={'username':'bob','password':'secret'})
+    assert resp.status_code == 200
+    cookies = resp.cookies
+
+    # With agent cookie only assigned driver should be returned
+    resp = client.get('/drivers', cookies={'agent': cookies.get('agent')})
+    assert resp.status_code == 200
+    assert resp.json() == ['d1']
+
+    # Query param all=true bypasses agent filtering
+    resp = client.get('/drivers?all=true', cookies={'agent': cookies.get('agent')})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 'd1' in data and 'd2' in data
+
+    # Clearing cookies should also return all drivers
+    client.cookies.clear()
+    resp = client.get('/drivers')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 'd1' in data and 'd2' in data


### PR DESCRIPTION
## Summary
- clear the agent cookie when admins log in
- allow `/drivers?all=true` to bypass agent filter
- test drivers endpoint when requesting all drivers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b3f2286c83218c0dcb0b7ee5047b