### PR TITLE
Improve return acceptance UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 .DS_Store
 Thumbs.db
 test.db
+merchants_test.db

--- a/backend/app/static/follow.html
+++ b/backend/app/static/follow.html
@@ -321,9 +321,13 @@ function applyNotesRange(){
 
 function acceptReturn(driver,order,btn){
   btn.disabled=true;
+  const row = btn.closest('tr');
+  row.style.opacity='0.5';
+  const original = btn.textContent;
+  btn.textContent='Processing...';
   apiPost('/order/accept-return?driver='+driver,{order_name:order})
-    .then(()=>{btn.closest('tr').style.opacity='0.5';loadOrders(driversCache);loadArchive(driversCache);loadNotes(driversCache);})
-    .catch(e=>{alert('Error: '+e);btn.disabled=false;});
+    .then(()=>{loadOrders(driversCache);loadArchive(driversCache);loadNotes(driversCache);})
+    .catch(e=>{alert('Error: '+e);btn.disabled=false;row.style.opacity='1';btn.textContent=original;});
 }
 
 


### PR DESCRIPTION
## Summary
- make the "Accept Return" button update immediately while the request is processing
- ignore merchants_test.db test artifact

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e8322d608321b9dda13de6cc1299