### PR TITLE
Include merchants in admin agent list

### DIFF
--- a/backend/app/static/admin_dashboard.html
+++ b/backend/app/static/admin_dashboard.html
@@ -520,8 +520,7 @@ function renderAgentCards(){
   list.innerHTML=items.map(a=>{
     const initials=a.username.slice(0,2).toUpperCase();
     const driverChips=a.drivers.length===driversData.length?`<span class="chip chip-driver">All Drivers</span>`:a.drivers.map(d=>`<span class="chip chip-driver">${d}</span>`).join('');
-    const merchAssigned=merchantsData.filter(m=>m.agents.includes(a.username)).map(m=>m.name);
-    const merchChips=merchAssigned.length===merchantsData.length?`<span class="chip chip-merchant">All Merchants</span>`:merchAssigned.map(m=>`<span class="chip chip-merchant">${m}</span>`).join('');
+    const merchChips=a.merchants.length===merchantsData.length?`<span class="chip chip-merchant">All Merchants</span>`:a.merchants.map(m=>`<span class="chip chip-merchant">${m}</span>`).join('');
     return `<div class="p-2 bg-white rounded shadow hover:shadow-md flex justify-between items-start"><div><div class="flex items-center gap-2"><div class="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center font-semibold">${initials}</div><span class="font-bold text-lg">${a.username}</span><span class="text-xs bg-gray-200 px-1 rounded">Agent</span></div><div class="mt-1 flex flex-wrap">${driverChips}${merchChips}</div></div><button class="text-blue-600" onclick="openDrawer('${a.username}')">✏️</button></div>`;
   }).join('');
 }

--- a/backend/tests/test_admin_agents.py
+++ b/backend/tests/test_admin_agents.py
@@ -1,0 +1,58 @@
+import os, asyncio, sys, importlib
+from fastapi.testclient import TestClient
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+DB_FILE = 'admin_agents.db'
+
+
+def setup_app():
+    old = os.environ.get('DATABASE_URL')
+    if os.path.exists(DB_FILE):
+        os.remove(DB_FILE)
+    os.environ['DATABASE_URL'] = f'sqlite+aiosqlite:///{DB_FILE}'
+    from app import main as app_main
+    from app import db as app_db
+    from app import models as app_models
+    importlib.reload(app_db)
+    importlib.reload(app_models)
+    importlib.reload(app_main)
+    client = TestClient(app_main.app)
+    asyncio.run(app_main.init_db())
+    return app_main, app_db, app_models, client, old
+
+
+def reset_app(old):
+    if old:
+        os.environ['DATABASE_URL'] = old
+    from app import main as app_main
+    from app import db as app_db
+    from app import models as app_models
+    importlib.reload(app_db)
+    importlib.reload(app_models)
+    importlib.reload(app_main)
+    asyncio.run(app_main.init_db())
+
+
+async def create_records(db, models):
+    async with db.AsyncSessionLocal() as session:
+        d1 = models.Driver(id='d1')
+        agent = models.Agent(username='bob', password='pw', drivers=[d1])
+        merchant = models.Merchant(name='Shop', drivers=[d1], agents=[agent])
+        session.add_all([d1, agent, merchant])
+        await session.commit()
+
+
+def test_admin_agents_include_merchants():
+    app_main, app_db, app_models, client, old_db = setup_app()
+    asyncio.run(create_records(app_db, app_models))
+
+    resp = client.get('/admin/agents')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    agent = data[0]
+    assert agent['username'] == 'bob'
+    assert agent['drivers'] == ['d1']
+    assert agent['merchants'] == ['Shop']
+
+    reset_app(old_db)


### PR DESCRIPTION
## Summary
- extend `AgentOut` with a `merchants` list
- return assigned merchants from `/admin/agents`
- show merchants directly in agent cards
- verify merchant assignments in new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883ef3600c48321b57ba8d304870024