### PR TITLE
Update agent password handling

### DIFF
--- a/backend/app/static/admin_dashboard.html
+++ b/backend/app/static/admin_dashboard.html
@@ -572,7 +572,10 @@ document.getElementById('drawerCancel').addEventListener('click',closeDrawer);
 async function saveAssignments(){
   if(!currentAgent)return;
   if(editDrivers.size===0&&editMerchants.size===0){if(!confirm('This agent will have no data. Continue?'))return;}
-  await fetch(`/admin/agents/${encodeURIComponent(currentAgent)}`,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({drivers:Array.from(editDrivers)})});
+  const pw=document.getElementById('drawerPassword').value.trim();
+  const payload={drivers:Array.from(editDrivers)};
+  if(pw)payload.password=pw;
+  await fetch(`/admin/agents/${encodeURIComponent(currentAgent)}`,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
   for(const m of merchantsData){
     const assigned=editMerchants.has(m.id);const agents=new Set(m.agents);
     if(assigned)agents.add(currentAgent);else agents.delete(currentAgent);

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -71,3 +71,18 @@ def test_drivers_all_query():
     assert resp.status_code == 200
     data = resp.json()
     assert 'd1' in data and 'd2' in data
+
+
+def test_create_agent_without_password_fails():
+    app_main, app_db, app_models, client = setup_app()
+    resp = client.post('/admin/agents', json={'username': 'nopass'})
+    assert resp.status_code == 400
+
+
+def test_update_agent_without_password():
+    app_main, app_db, app_models, client = setup_app()
+    asyncio.run(create_agent(app_db, app_models, username='editme'))
+    resp = client.put('/admin/agents/editme', json={'username':'editme','drivers': ['d1', 'd2']})
+    assert resp.status_code == 200
+
+


### PR DESCRIPTION
## Summary
- allow AgentIn password to be optional
- require password on agent creation
- update password only when provided
- pass optional password from admin dashboard
- test agent creation without password and updating assignments without password

## Testing
- `pytest backend/tests/test_agents.py::test_create_agent_without_password_fails backend/tests/test_agents.py::test_update_agent_without_password -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883ef2c211c8321ab010874b9fa9ae1